### PR TITLE
refactor(core): rename mj_ prefix to mjc_ for C API consistency

### DIFF
--- a/core/core/mjc_physics_runtime.h
+++ b/core/core/mjc_physics_runtime.h
@@ -7,6 +7,7 @@
 
 #include <mujoco/mujoco.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -98,114 +99,114 @@ typedef struct {
 
 /// Create a new runtime instance with the given configuration
 /// Returns NULL on failure
-MJRuntimeHandle mj_runtime_create(const MJRuntimeConfig* config);
+MJRuntimeHandle mjc_runtime_create(const MJRuntimeConfig* config);
 
 /// Destroy a runtime instance and free all resources
-void mj_runtime_destroy(MJRuntimeHandle handle);
+void mjc_runtime_destroy(MJRuntimeHandle handle);
 
 // MARK: - Model Loading
 
 /// Load a model from an XML file path
-bool mj_runtime_load_model(MJRuntimeHandle handle,
+bool mjc_runtime_load_model(MJRuntimeHandle handle,
                            const char* xmlPath,
                            char* errorBuffer,
                            int32_t errorBufferSize);
 
 /// Load a model from an XML string
-bool mj_runtime_load_model_xml(MJRuntimeHandle handle,
+bool mjc_runtime_load_model_xml(MJRuntimeHandle handle,
                                const char* xmlString,
                                char* errorBuffer,
                                int32_t errorBufferSize);
 
 /// Unload the current model
-void mj_runtime_unload(MJRuntimeHandle handle);
+void mjc_runtime_unload(MJRuntimeHandle handle);
 
 // MARK: - Simulation Control
 
 /// Start the physics simulation (runs on dedicated thread)
-void mj_runtime_start(MJRuntimeHandle handle);
+void mjc_runtime_start(MJRuntimeHandle handle);
 
 /// Pause the physics simulation
-void mj_runtime_pause(MJRuntimeHandle handle);
+void mjc_runtime_pause(MJRuntimeHandle handle);
 
 /// Reset the simulation to initial state.
 /// WARNING: Not thread-safe while simulation is running.
-/// Call mj_runtime_pause() first, then reset, then mj_runtime_start().
-void mj_runtime_reset(MJRuntimeHandle handle);
+/// Call mjc_runtime_pause() first, then reset, then mjc_runtime_start().
+void mjc_runtime_reset(MJRuntimeHandle handle);
 
 /// Step the simulation manually (when paused)
-void mj_runtime_step(MJRuntimeHandle handle);
+void mjc_runtime_step(MJRuntimeHandle handle);
 
 /// Get the current simulation state
-MJRuntimeState mj_runtime_get_state(MJRuntimeHandle handle);
+MJRuntimeState mjc_runtime_get_state(MJRuntimeHandle handle);
 
 /// Get simulation statistics
-MJRuntimeStats mj_runtime_get_stats(MJRuntimeHandle handle);
+MJRuntimeStats mjc_runtime_get_stats(MJRuntimeHandle handle);
 
 // MARK: - Ring Buffer API (Lock-Free Frame Access)
 
 /// Wait for a new frame from the physics thread (blocking)
 /// Returns pointer to the latest completed frame
 /// Use this when you want to synchronize render with physics
-const MJFrameData* mj_runtime_wait_for_frame(MJRuntimeHandle handle);
+const MJFrameData* mjc_runtime_wait_for_frame(MJRuntimeHandle handle);
 
 /// Get the latest available frame without waiting (non-blocking)
 /// May return the same frame multiple times if physics is slower than render
 /// Use this for non-blocking render loop
-const MJFrameData* mj_runtime_get_latest_frame(MJRuntimeHandle handle);
+const MJFrameData* mjc_runtime_get_latest_frame(MJRuntimeHandle handle);
 
 /// Get the current frame count (for tracking new frames)
-uint64_t mj_runtime_get_frame_count(MJRuntimeHandle handle);
+uint64_t mjc_runtime_get_frame_count(MJRuntimeHandle handle);
 
 // MARK: - Frame Data Accessors (for Swift interop)
 
 /// Get pointer to the geoms array in a frame
-const MJGeomInstance* mj_frame_get_geoms(const MJFrameData* frame);
+const MJGeomInstance* mjc_frame_get_geoms(const MJFrameData* frame);
 
 /// Get the geom count from a frame
-int32_t mj_frame_get_geom_count(const MJFrameData* frame);
+int32_t mjc_frame_get_geom_count(const MJFrameData* frame);
 
 /// Get a specific geom by index from a frame
-const MJGeomInstance* mj_frame_get_geom(const MJFrameData* frame, int32_t index);
+const MJGeomInstance* mjc_frame_get_geom(const MJFrameData* frame, int32_t index);
 
 // MARK: - Legacy Scene Access (for compatibility)
 
 /// Lock/unlock are no-ops with ring buffer, kept for API compatibility
-void mj_runtime_lock(MJRuntimeHandle handle);
-void mj_runtime_unlock(MJRuntimeHandle handle);
+void mjc_runtime_lock(MJRuntimeHandle handle);
+void mjc_runtime_unlock(MJRuntimeHandle handle);
 
 /// Update scene - no-op with ring buffer, scene is updated automatically
-void mj_runtime_update_scene(MJRuntimeHandle handle);
+void mjc_runtime_update_scene(MJRuntimeHandle handle);
 
 /// Get pointer to mjvScene (legacy, prefer ring buffer API)
-const mjvScene* mj_runtime_get_scene(MJRuntimeHandle handle);
+const mjvScene* mjc_runtime_get_scene(MJRuntimeHandle handle);
 
 /// Get pointer to mjvCamera
-mjvCamera* mj_runtime_get_camera(MJRuntimeHandle handle);
+mjvCamera* mjc_runtime_get_camera(MJRuntimeHandle handle);
 
 /// Get pointer to mjvOption
-mjvOption* mj_runtime_get_option(MJRuntimeHandle handle);
+mjvOption* mjc_runtime_get_option(MJRuntimeHandle handle);
 
 /// Get pointer to mjModel (read-only)
-const mjModel* mj_runtime_get_model(MJRuntimeHandle handle);
+const mjModel* mjc_runtime_get_model(MJRuntimeHandle handle);
 
 /// Get pointer to mjData (read-only)
-const mjData* mj_runtime_get_data(MJRuntimeHandle handle);
+const mjData* mjc_runtime_get_data(MJRuntimeHandle handle);
 
 // MARK: - Camera Control
 // NOTE: Camera methods are not synchronized with physics thread.
 // For best results, call these when simulation is paused or from main thread only.
 
-void mj_runtime_set_camera_azimuth(MJRuntimeHandle handle, double azimuth);
-void mj_runtime_set_camera_elevation(MJRuntimeHandle handle, double elevation);
-void mj_runtime_set_camera_distance(MJRuntimeHandle handle, double distance);
-void mj_runtime_set_camera_lookat(MJRuntimeHandle handle, double x, double y, double z);
-void mj_runtime_reset_camera(MJRuntimeHandle handle);
+void mjc_runtime_set_camera_azimuth(MJRuntimeHandle handle, double azimuth);
+void mjc_runtime_set_camera_elevation(MJRuntimeHandle handle, double elevation);
+void mjc_runtime_set_camera_distance(MJRuntimeHandle handle, double distance);
+void mjc_runtime_set_camera_lookat(MJRuntimeHandle handle, double x, double y, double z);
+void mjc_runtime_reset_camera(MJRuntimeHandle handle);
 
 // MARK: - Real-time Control
 
-void mj_runtime_set_realtime_factor(MJRuntimeHandle handle, double factor);
-double mj_runtime_get_realtime_factor(MJRuntimeHandle handle);
+void mjc_runtime_set_realtime_factor(MJRuntimeHandle handle, double factor);
+double mjc_runtime_get_realtime_factor(MJRuntimeHandle handle);
 
 #ifdef __cplusplus
 }

--- a/core/core/mjc_physics_runtime.mm
+++ b/core/core/mjc_physics_runtime.mm
@@ -973,7 +973,7 @@ private:
 
 extern "C" {
 
-MJRuntimeHandle mj_runtime_create(const MJRuntimeConfig* config) {
+MJRuntimeHandle mjc_runtime_create(const MJRuntimeConfig* config) {
     if (!config) return nullptr;
     try {
         return new MJSimulationRuntime(*config);
@@ -982,11 +982,11 @@ MJRuntimeHandle mj_runtime_create(const MJRuntimeConfig* config) {
     }
 }
 
-void mj_runtime_destroy(MJRuntimeHandle handle) {
+void mjc_runtime_destroy(MJRuntimeHandle handle) {
     delete static_cast<MJSimulationRuntime*>(handle);
 }
 
-bool mj_runtime_load_model(MJRuntimeHandle handle,
+bool mjc_runtime_load_model(MJRuntimeHandle handle,
                            const char* xmlPath,
                            char* errorBuffer,
                            int32_t errorBufferSize) {
@@ -994,7 +994,7 @@ bool mj_runtime_load_model(MJRuntimeHandle handle,
     return static_cast<MJSimulationRuntime*>(handle)->LoadModel(xmlPath, errorBuffer, errorBufferSize);
 }
 
-bool mj_runtime_load_model_xml(MJRuntimeHandle handle,
+bool mjc_runtime_load_model_xml(MJRuntimeHandle handle,
                                const char* xmlString,
                                char* errorBuffer,
                                int32_t errorBufferSize) {
@@ -1002,137 +1002,137 @@ bool mj_runtime_load_model_xml(MJRuntimeHandle handle,
     return static_cast<MJSimulationRuntime*>(handle)->LoadModelXML(xmlString, errorBuffer, errorBufferSize);
 }
 
-void mj_runtime_unload(MJRuntimeHandle handle) {
+void mjc_runtime_unload(MJRuntimeHandle handle) {
     if (handle) static_cast<MJSimulationRuntime*>(handle)->Unload();
 }
 
-void mj_runtime_start(MJRuntimeHandle handle) {
+void mjc_runtime_start(MJRuntimeHandle handle) {
     if (handle) static_cast<MJSimulationRuntime*>(handle)->Start();
 }
 
-void mj_runtime_pause(MJRuntimeHandle handle) {
+void mjc_runtime_pause(MJRuntimeHandle handle) {
     if (handle) static_cast<MJSimulationRuntime*>(handle)->Pause();
 }
 
-void mj_runtime_reset(MJRuntimeHandle handle) {
+void mjc_runtime_reset(MJRuntimeHandle handle) {
     if (handle) static_cast<MJSimulationRuntime*>(handle)->Reset();
 }
 
-void mj_runtime_step(MJRuntimeHandle handle) {
+void mjc_runtime_step(MJRuntimeHandle handle) {
     if (handle) static_cast<MJSimulationRuntime*>(handle)->Step();
 }
 
-MJRuntimeState mj_runtime_get_state(MJRuntimeHandle handle) {
+MJRuntimeState mjc_runtime_get_state(MJRuntimeHandle handle) {
     if (!handle) return MJRuntimeStateInactive;
     return static_cast<MJSimulationRuntime*>(handle)->GetState();
 }
 
-MJRuntimeStats mj_runtime_get_stats(MJRuntimeHandle handle) {
+MJRuntimeStats mjc_runtime_get_stats(MJRuntimeHandle handle) {
     if (!handle) return MJRuntimeStats{0, 1.0, 0.002, 0};
     return static_cast<MJSimulationRuntime*>(handle)->GetStats();
 }
 
 // Legacy scene access (for compatibility)
-void mj_runtime_lock(MJRuntimeHandle handle) {
+void mjc_runtime_lock(MJRuntimeHandle handle) {
     // No-op with ring buffer - kept for API compatibility
 }
 
-void mj_runtime_unlock(MJRuntimeHandle handle) {
+void mjc_runtime_unlock(MJRuntimeHandle handle) {
     // No-op with ring buffer - kept for API compatibility
 }
 
-void mj_runtime_update_scene(MJRuntimeHandle handle) {
+void mjc_runtime_update_scene(MJRuntimeHandle handle) {
     // No-op - scene is updated in ring buffer automatically
 }
 
-const mjvScene* mj_runtime_get_scene(MJRuntimeHandle handle) {
+const mjvScene* mjc_runtime_get_scene(MJRuntimeHandle handle) {
     if (!handle) return nullptr;
     return static_cast<MJSimulationRuntime*>(handle)->GetScene();
 }
 
-mjvCamera* mj_runtime_get_camera(MJRuntimeHandle handle) {
+mjvCamera* mjc_runtime_get_camera(MJRuntimeHandle handle) {
     if (!handle) return nullptr;
     return static_cast<MJSimulationRuntime*>(handle)->GetCamera();
 }
 
-mjvOption* mj_runtime_get_option(MJRuntimeHandle handle) {
+mjvOption* mjc_runtime_get_option(MJRuntimeHandle handle) {
     if (!handle) return nullptr;
     return static_cast<MJSimulationRuntime*>(handle)->GetOption();
 }
 
-const mjModel* mj_runtime_get_model(MJRuntimeHandle handle) {
+const mjModel* mjc_runtime_get_model(MJRuntimeHandle handle) {
     if (!handle) return nullptr;
     return static_cast<MJSimulationRuntime*>(handle)->GetModel();
 }
 
-const mjData* mj_runtime_get_data(MJRuntimeHandle handle) {
+const mjData* mjc_runtime_get_data(MJRuntimeHandle handle) {
     if (!handle) return nullptr;
     return static_cast<MJSimulationRuntime*>(handle)->GetData();
 }
 
 // New ring buffer API
-const MJFrameData* mj_runtime_wait_for_frame(MJRuntimeHandle handle) {
+const MJFrameData* mjc_runtime_wait_for_frame(MJRuntimeHandle handle) {
     if (!handle) return nullptr;
     // Cast internal FrameData to MJFrameData (same memory layout)
     return reinterpret_cast<const MJFrameData*>(
         static_cast<MJSimulationRuntime*>(handle)->WaitForFrame());
 }
 
-const MJFrameData* mj_runtime_get_latest_frame(MJRuntimeHandle handle) {
+const MJFrameData* mjc_runtime_get_latest_frame(MJRuntimeHandle handle) {
     if (!handle) return nullptr;
     // Cast internal FrameData to MJFrameData (same memory layout)
     return reinterpret_cast<const MJFrameData*>(
         static_cast<MJSimulationRuntime*>(handle)->GetLatestFrame());
 }
 
-uint64_t mj_runtime_get_frame_count(MJRuntimeHandle handle) {
+uint64_t mjc_runtime_get_frame_count(MJRuntimeHandle handle) {
     if (!handle) return 0;
     return static_cast<MJSimulationRuntime*>(handle)->GetFrameCount();
 }
 
 // Frame data accessors (for Swift interop with large fixed-size arrays)
-const MJGeomInstance* mj_frame_get_geoms(const MJFrameData* frame) {
+const MJGeomInstance* mjc_frame_get_geoms(const MJFrameData* frame) {
     if (!frame) return nullptr;
     // The geoms array in MJFrameData starts at offset 0
     return frame->geoms;
 }
 
-int32_t mj_frame_get_geom_count(const MJFrameData* frame) {
+int32_t mjc_frame_get_geom_count(const MJFrameData* frame) {
     if (!frame) return 0;
     return frame->geom_count;
 }
 
-const MJGeomInstance* mj_frame_get_geom(const MJFrameData* frame, int32_t index) {
+const MJGeomInstance* mjc_frame_get_geom(const MJFrameData* frame, int32_t index) {
     if (!frame || index < 0 || index >= frame->geom_count) return nullptr;
     return &frame->geoms[index];
 }
 
 // Camera control
-void mj_runtime_set_camera_azimuth(MJRuntimeHandle handle, double azimuth) {
+void mjc_runtime_set_camera_azimuth(MJRuntimeHandle handle, double azimuth) {
     if (handle) static_cast<MJSimulationRuntime*>(handle)->SetCameraAzimuth(azimuth);
 }
 
-void mj_runtime_set_camera_elevation(MJRuntimeHandle handle, double elevation) {
+void mjc_runtime_set_camera_elevation(MJRuntimeHandle handle, double elevation) {
     if (handle) static_cast<MJSimulationRuntime*>(handle)->SetCameraElevation(elevation);
 }
 
-void mj_runtime_set_camera_distance(MJRuntimeHandle handle, double distance) {
+void mjc_runtime_set_camera_distance(MJRuntimeHandle handle, double distance) {
     if (handle) static_cast<MJSimulationRuntime*>(handle)->SetCameraDistance(distance);
 }
 
-void mj_runtime_set_camera_lookat(MJRuntimeHandle handle, double x, double y, double z) {
+void mjc_runtime_set_camera_lookat(MJRuntimeHandle handle, double x, double y, double z) {
     if (handle) static_cast<MJSimulationRuntime*>(handle)->SetCameraLookat(x, y, z);
 }
 
-void mj_runtime_reset_camera(MJRuntimeHandle handle) {
+void mjc_runtime_reset_camera(MJRuntimeHandle handle) {
     if (handle) static_cast<MJSimulationRuntime*>(handle)->ResetCamera();
 }
 
-void mj_runtime_set_realtime_factor(MJRuntimeHandle handle, double factor) {
+void mjc_runtime_set_realtime_factor(MJRuntimeHandle handle, double factor) {
     if (handle) static_cast<MJSimulationRuntime*>(handle)->SetRealtimeFactor(factor);
 }
 
-double mj_runtime_get_realtime_factor(MJRuntimeHandle handle) {
+double mjc_runtime_get_realtime_factor(MJRuntimeHandle handle) {
     if (!handle) return 1.0;
     return static_cast<MJSimulationRuntime*>(handle)->GetRealtimeFactor();
 }

--- a/core/core/mjc_runtime.swift
+++ b/core/core/mjc_runtime.swift
@@ -87,14 +87,14 @@ final class MJRuntime {
             udpPort: udpPort  // 0 = use default (8888 + instanceIndex)
         )
 
-        guard let h = mj_runtime_create(&config) else {
+        guard let h = mjc_runtime_create(&config) else {
             throw MJRuntimeError.creationFailed
         }
         self.handle = h
     }
 
     deinit {
-        mj_runtime_destroy(handle)
+        mjc_runtime_destroy(handle)
     }
 
     // MARK: - Model Loading
@@ -102,7 +102,7 @@ final class MJRuntime {
     /// Load a model from an XML file path
     func loadModel(fromFile path: String) throws {
         var errorBuffer = [CChar](repeating: 0, count: 1024)
-        let success = mj_runtime_load_model(
+        let success = mjc_runtime_load_model(
             handle,
             path,
             &errorBuffer,
@@ -118,7 +118,7 @@ final class MJRuntime {
     /// Load a model from an XML string
     func loadModel(fromXML xml: String) throws {
         var errorBuffer = [CChar](repeating: 0, count: 1024)
-        let success = mj_runtime_load_model_xml(
+        let success = mjc_runtime_load_model_xml(
             handle,
             xml,
             &errorBuffer,
@@ -133,41 +133,41 @@ final class MJRuntime {
 
     /// Unload the current model
     func unload() {
-        mj_runtime_unload(handle)
+        mjc_runtime_unload(handle)
     }
 
     // MARK: - Simulation Control
 
     /// Start the physics simulation (runs on dedicated C++ thread)
     func start() {
-        mj_runtime_start(handle)
+        mjc_runtime_start(handle)
     }
 
     /// Pause the physics simulation
     func pause() {
-        mj_runtime_pause(handle)
+        mjc_runtime_pause(handle)
     }
 
     /// Reset the simulation to initial state
     func reset() {
-        mj_runtime_reset(handle)
+        mjc_runtime_reset(handle)
     }
 
     /// Step the simulation manually (when paused)
     func step() {
-        mj_runtime_step(handle)
+        mjc_runtime_step(handle)
     }
 
     // MARK: - State Access
 
     /// Get the current simulation state
     var state: MJRuntimeSimulationState {
-        MJRuntimeSimulationState(from: mj_runtime_get_state(handle))
+        MJRuntimeSimulationState(from: mjc_runtime_get_state(handle))
     }
 
     /// Get simulation statistics
     var stats: MJRuntimeStatistics {
-        MJRuntimeStatistics(from: mj_runtime_get_stats(handle))
+        MJRuntimeStatistics(from: mjc_runtime_get_stats(handle))
     }
 
     /// Current simulation time
@@ -209,35 +209,35 @@ final class MJRuntime {
     /// Lock placeholder (no-op with current lock-free implementation).
     /// Retained for API compatibility; does not provide synchronization.
     func lock() {
-        mj_runtime_lock(handle)
+        mjc_runtime_lock(handle)
     }
 
     /// Unlock placeholder (no-op with current lock-free implementation).
     func unlock() {
-        mj_runtime_unlock(handle)
+        mjc_runtime_unlock(handle)
     }
 
     /// Update the visualization scene with current simulation state.
     func updateScene() {
-        mj_runtime_update_scene(handle)
+        mjc_runtime_update_scene(handle)
     }
 
     /// Get pointer to mjvScene for rendering.
     /// WARNING: Not thread-safe while physics is running. Use latestFrame instead.
     var scenePointer: UnsafePointer<mjvScene>? {
-        mj_runtime_get_scene(handle)
+        mjc_runtime_get_scene(handle)
     }
 
     /// Get pointer to mjvCamera.
     /// WARNING: Not thread-safe while physics is running.
     var cameraPointer: UnsafeMutablePointer<mjvCamera>? {
-        mj_runtime_get_camera(handle)
+        mjc_runtime_get_camera(handle)
     }
 
     /// Get pointer to mjvOption.
     /// WARNING: Not thread-safe while physics is running.
     var optionPointer: UnsafeMutablePointer<mjvOption>? {
-        mj_runtime_get_option(handle)
+        mjc_runtime_get_option(handle)
     }
 
     /// Execute a closure (lock/unlock are no-ops with lock-free implementation).
@@ -255,7 +255,7 @@ final class MJRuntime {
             withLock { cameraPointer?.pointee.azimuth ?? 90.0 }
         }
         set {
-            mj_runtime_set_camera_azimuth(handle, newValue)
+            mjc_runtime_set_camera_azimuth(handle, newValue)
         }
     }
 
@@ -264,7 +264,7 @@ final class MJRuntime {
             withLock { cameraPointer?.pointee.elevation ?? -15.0 }
         }
         set {
-            mj_runtime_set_camera_elevation(handle, newValue)
+            mjc_runtime_set_camera_elevation(handle, newValue)
         }
     }
 
@@ -273,23 +273,23 @@ final class MJRuntime {
             withLock { cameraPointer?.pointee.distance ?? 3.0 }
         }
         set {
-            mj_runtime_set_camera_distance(handle, newValue)
+            mjc_runtime_set_camera_distance(handle, newValue)
         }
     }
 
     func setCameraLookat(x: Double, y: Double, z: Double) {
-        mj_runtime_set_camera_lookat(handle, x, y, z)
+        mjc_runtime_set_camera_lookat(handle, x, y, z)
     }
 
     func resetCamera() {
-        mj_runtime_reset_camera(handle)
+        mjc_runtime_reset_camera(handle)
     }
 
     // MARK: - Real-time Control
 
     var realtimeFactor: Double {
-        get { mj_runtime_get_realtime_factor(handle) }
-        set { mj_runtime_set_realtime_factor(handle, newValue) }
+        get { mjc_runtime_get_realtime_factor(handle) }
+        set { mjc_runtime_set_realtime_factor(handle, newValue) }
     }
 
     // MARK: - Ring Buffer API (Lock-Free Frame Access)
@@ -298,7 +298,7 @@ final class MJRuntime {
     /// May return the same frame multiple times if physics is slower than render
     /// Returns nil if no frame is available yet
     var latestFrame: UnsafePointer<MJFrameData>? {
-        mj_runtime_get_latest_frame(handle)
+        mjc_runtime_get_latest_frame(handle)
     }
 
     /// Wait for a new frame from the physics thread (blocking).
@@ -306,11 +306,11 @@ final class MJRuntime {
     /// The runtime internally tracks the last delivered frame, blocking
     /// until a strictly newer frame is available.
     func waitForFrame() -> UnsafePointer<MJFrameData>? {
-        mj_runtime_wait_for_frame(handle)
+        mjc_runtime_wait_for_frame(handle)
     }
 
     /// Get the current frame count (for tracking new frames)
     var frameCount: UInt64 {
-        mj_runtime_get_frame_count(handle)
+        mjc_runtime_get_frame_count(handle)
     }
 }


### PR DESCRIPTION
- Rename all mj_runtime_* functions to mjc_runtime_*
- Rename all mj_frame_* functions to mjc_frame_*
- Add stddef.h include for NULL definition

This makes the C function naming consistent with the file naming convention (mjc_physics_runtime.h).