### PR TITLE
chore(app): bump marketing version to 1.0.0

### DIFF
--- a/imujoco/app/app.xcodeproj/project.pbxproj
+++ b/imujoco/app/app.xcodeproj/project.pbxproj
@@ -338,7 +338,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 0.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hhkblogi.imujoco.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -400,7 +400,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 0.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hhkblogi.imujoco.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary
- Update `MARKETING_VERSION` from `0.0` to `1.0.0` in both Debug and Release build configurations
- App Store requires a valid semver version for submission

## Test plan
- [x] Open `imujoco.xcworkspace` and verify version shows 1.0.0 in General tab
- [x] Build succeeds on all targets (iOS, tvOS, macOS)
