### PR TITLE
chore(app): add PrivacyInfo.xcprivacy privacy manifest

### DIFF
--- a/imujoco/app/app/PrivacyInfo.xcprivacy
+++ b/imujoco/app/app/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Add `PrivacyInfo.xcprivacy` to the app target (auto-included via file system sync)
- Required for App Store submission since Spring 2024
- Declares no tracking, no data collection
- Declares `NSPrivacyAccessedAPICategorySystemBootTime` (reason `35F9.1`) for MTKView/CACurrentMediaTime() timing in Metal rendering

## Test plan
- [x] Open workspace, verify PrivacyInfo.xcprivacy appears in app target
- [x] Build — verify privacy manifest is included in the app bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)