### PR TITLE
chore(app): add NSLocalNetworkUsageDescription

### DIFF
--- a/imujoco/app/app.xcodeproj/project.pbxproj
+++ b/imujoco/app/app.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = iMuJoCo;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "iMuJoCo uses the local network to receive simulation controls and send state updates via UDP from a Python driver on your computer.";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "iMuJoCo uses the local network to communicate with a Python driver on your computer via UDP, receiving simulation controls and sending state updates.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -387,7 +387,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = iMuJoCo;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "iMuJoCo uses the local network to receive simulation controls and send state updates via UDP from a Python driver on your computer.";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "iMuJoCo uses the local network to communicate with a Python driver on your computer via UDP, receiving simulation controls and sending state updates.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;


### PR DESCRIPTION
## Summary
- Add `NSLocalNetworkUsageDescription` to Info.plist via build settings
- Explains UDP usage for receiving simulation controls from Python driver
- Required for iOS local network permission prompt (shown when app first opens UDP socket)

## Test plan
- [ ] Build and run on iOS device
- [ ] Verify local network permission prompt shows the description text
- [ ] Verify UDP communication works after granting permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)