### PR TITLE
fix(app): fix port display in menu bar and simulation cells

### DIFF
--- a/imujoco/app/app/fullscreen_simulation_view.swift
+++ b/imujoco/app/app/fullscreen_simulation_view.swift
@@ -105,7 +105,7 @@ struct FullscreenSimulationView: View {
                     .font(.headline)
                     .foregroundColor(.white)
 
-                Text("Port \(instance.port)")
+                Text(verbatim: "Port \(instance.port)")
                     .font(.caption)
                     .foregroundColor(.white.opacity(0.7))
             }

--- a/imujoco/app/app/simulation_cell_view.swift
+++ b/imujoco/app/app/simulation_cell_view.swift
@@ -68,7 +68,7 @@ struct SimulationCellView: View {
 
                     Spacer()
 
-                    Text(":\(instance.port)")
+                    Text(verbatim: ":\(instance.port)")
                         .font(.caption2)
                         .fontWeight(.medium)
                         .foregroundColor(.white.opacity(0.7))

--- a/imujoco/app/app/simulation_grid_view.swift
+++ b/imujoco/app/app/simulation_grid_view.swift
@@ -182,11 +182,6 @@ struct SimulationGridView: View {
                 Text(deviceIP)
                     .font(.system(.subheadline, design: .monospaced))
                     .foregroundColor(.white)
-
-                // Port range
-                Text("UDP :8888-8891")
-                    .font(.caption)
-                    .foregroundColor(.white.opacity(0.7))
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)


### PR DESCRIPTION
## Summary
- Remove redundant "UDP :8888-8891" port range from menu bar to fix IP address wrapping on narrow screens (e.g. iPhone 16e)
- Fix port number locale formatting: `:8,888` → `:8888` using `Text(verbatim:)` in both grid cell and fullscreen views

## Changes
| File | Change |
|------|--------|
| `simulation_grid_view.swift` | Remove "UDP :8888-8891" from menu bar |
| `simulation_cell_view.swift` | Use `Text(verbatim:)` for port display |
| `fullscreen_simulation_view.swift` | Use `Text(verbatim:)` for port display |

## Test plan
- [x] Build and run on iPhone 16e
- [x] Verify IP address displays fully without wrapping in menu bar
- [x] Verify each simulation cell shows port as `:8888` (no comma)
- [x] Verify fullscreen view shows port as `Port 8888` (no comma)

🤖 Generated with [Claude Code](https://claude.com/claude-code)