### PR TITLE
chore(gitignore): add .vscode to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ build/
 # Local settings (contains DEVELOPMENT_TEAM, etc.)
 local.xcconfig
 .python-version
+
+# VS Code
+.vscode/


### PR DESCRIPTION
## Summary
Add .vscode/ to .gitignore to prevent local IDE settings from being tracked.

## Changes
- .gitignore - Added .vscode/

## Test plan
- [x] Verified .vscode/ files are ignored by git