### PR TITLE
feat(ui): add About page to settings

### DIFF
--- a/imujoco/app/app/simulation_grid_view.swift
+++ b/imujoco/app/app/simulation_grid_view.swift
@@ -476,6 +476,8 @@ struct SettingsView: View {
 // MARK: - About View
 
 struct AboutView: View {
+    @Environment(\.dismiss) private var dismiss
+
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "–"
     }
@@ -537,6 +539,15 @@ struct AboutView: View {
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigation) {
+                Button(action: { dismiss() }) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 14, weight: .medium))
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add About page accessible via NavigationLink in Settings sheet
- Shows app version/build, MuJoCo version, Apache 2.0 license, and app icon credit (crabe.art)
- Lists bundled models with their source and license info
- Uses compact chevron-only back button

## Test plan
- [x] Open settings sheet, verify "About" row appears below Default View
- [x] Tap About, verify version (0.1.0), build (1), MuJoCo (3.4.0), license, and app icon rows
- [x] Verify 3 bundled models listed with source and license
- [x] Verify compact back button navigates back to settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)