### PR TITLE
fix(ui): guard DragGesture for tvOS availability

### DIFF
--- a/imujoco/app/app/fullscreen_simulation_view.swift
+++ b/imujoco/app/app/fullscreen_simulation_view.swift
@@ -65,6 +65,7 @@ struct FullscreenSimulationView: View {
                     tintColor: overlaySecondaryTextColor(brightness: brightness)
                 )
                 .opacity(isNavigating ? 0 : 1)
+                #if !os(tvOS)
                 .gesture(
                     DragGesture(minimumDistance: 0, coordinateSpace: .global)
                         .onChanged { value in
@@ -91,6 +92,7 @@ struct FullscreenSimulationView: View {
                             hoveredCell = nil
                         }
                 )
+                #endif
                 .padding(.bottom, 12)
             }
         }

--- a/imujoco/app/app/simulation_cell_view.swift
+++ b/imujoco/app/app/simulation_cell_view.swift
@@ -114,6 +114,11 @@ struct LongPressButton: View {
                     .rotationEffect(.degrees(-90))
                     .padding(1)
             )
+            #if os(tvOS)
+            .onLongPressGesture(minimumDuration: duration) {
+                action()
+            }
+            #else
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { _ in
@@ -143,6 +148,7 @@ struct LongPressButton: View {
                         }
                     }
             )
+            #endif
     }
 }
 


### PR DESCRIPTION
## Summary
- `DragGesture` is not available on tvOS — guards both usages with `#if !os(tvOS)`
- In `fullscreen_simulation_view.swift`: disables the navigation drag on the layout icon (tvOS uses Siri Remote focus instead)
- In `simulation_cell_view.swift`: replaces the custom `DragGesture`-based long press with native `.onLongPressGesture` on tvOS

## Test plan
- [x] `bazel build //...` — all 29 targets pass (iOS, macOS, tvOS)
- [ ] Verify long-press button works on tvOS with Siri Remote
- [x] Verify drag navigation still works on iOS/macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)