### PR TITLE
fix(ui): restyle model picker rows for iOS 26

### DIFF
--- a/imujoco/app/app/simulation_grid_view.swift
+++ b/imujoco/app/app/simulation_grid_view.swift
@@ -297,21 +297,18 @@ struct ModelPickerView: View {
             List {
                 if !modelGroups.isEmpty {
                     ForEach(modelGroups, id: \.source) { group in
-                        Section {
-                            ForEach(group.models, id: \.name) { model in
-                                PressableRow(action: { onSelectModel(model.name) }) {
-                                    HStack {
-                                        Text(model.name)
-                                        Spacer()
-                                    }
+                        Text(group.source.rawValue)
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.secondary)
+                            .listRowSeparator(.hidden)
+                        ForEach(group.models, id: \.name) { model in
+                            PressableRow(action: { onSelectModel(model.name) }) {
+                                HStack {
+                                    Text(model.name)
+                                    Spacer()
                                 }
                             }
-                        } header: {
-                            Text(group.source.rawValue)
-                                .font(.subheadline)
-                                .fontWeight(.semibold)
-                                .foregroundStyle(.secondary)
-                                .textCase(nil)
                         }
                     }
                 } else {


### PR DESCRIPTION
## Summary
- Replace `Button` with a custom `PressableRow` view using `DragGesture` to avoid iOS 26 Liquid Glass rendering each row as a glassy button container
- Add opacity-based press feedback (dims to 50% on tap) so rows still feel interactive
- Switch to `.listStyle(.plain)` with styled `Section` headers so group labels ("iMuJoCo", "MuJoCo", "Menagerie") scroll with content instead of sticking at the top

## Test plan
- [x] `bazel build //imujoco/app:app` — iOS builds
- [ ] `bazel build //imujoco/app:app_macos` — macOS builds
- [x] Visual check: rows in Select Model sheet no longer have rounded glassy button containers
- [x] Visual check: tapping a row shows dimming feedback
- [x] Visual check: section headers scroll with content, not pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)