### PR TITLE
feat(ui): add configurable triple-click action setting

### DIFF
--- a/imujoco/app/app/fullscreen_simulation_view.swift
+++ b/imujoco/app/app/fullscreen_simulation_view.swift
@@ -11,6 +11,7 @@ struct FullscreenSimulationView: View {
     var onSwitchInstance: (Int) -> Void  // -1 = grid, 0-3 = instance
     var onLoadModel: () -> Void
 
+    @AppStorage("tripleClickAction") private var tripleClickAction: Int = 0
     @State private var showMetrics = true
     @State private var resetProgress: CGFloat = 0
     @State private var stopProgress: CGFloat = 0
@@ -98,9 +99,13 @@ struct FullscreenSimulationView: View {
         }
         .background(Color.black)
         .contentShape(Rectangle())
-        .onTripleTap(dotColor: instance.isActive ? overlayTextColor(brightness: brightness) : .gray, targetLabel: "grid view") {
-            withAnimation(.easeInOut(duration: 0.3)) {
-                onExit()
+        .onTripleTap(dotColor: instance.isActive ? overlayTextColor(brightness: brightness) : .gray, targetLabel: tripleClickAction == 0 ? "grid view" : (instance.isActive ? "lock/unlock" : "")) {
+            if tripleClickAction == 0 {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    onExit()
+                }
+            } else if instance.isActive {
+                instance.isLocked.toggle()
             }
         }
         #if os(iOS)

--- a/imujoco/app/app/simulation_cell_view.swift
+++ b/imujoco/app/app/simulation_cell_view.swift
@@ -215,6 +215,7 @@ struct SimulationCellView: View {
     var onTapFullscreen: () -> Void
     var onLoadModel: () -> Void
 
+    @AppStorage("tripleClickAction") private var tripleClickAction: Int = 0
     @State private var resetProgress: CGFloat = 0
     @State private var stopProgress: CGFloat = 0
 
@@ -421,8 +422,12 @@ struct SimulationCellView: View {
             }
         }
         .contentShape(Rectangle())
-        .onTripleTap(dotColor: overlayTextColor(brightness: brightness), targetLabel: "fullscreen") {
-            onTapFullscreen()
+        .onTripleTap(dotColor: overlayTextColor(brightness: brightness), targetLabel: tripleClickAction == 0 ? "fullscreen" : "lock/unlock") {
+            if tripleClickAction == 0 {
+                onTapFullscreen()
+            } else {
+                instance.isLocked.toggle()
+            }
         }
     }
 
@@ -526,8 +531,10 @@ struct SimulationCellView: View {
             .padding(.bottom, 6)
         }
         .contentShape(Rectangle())
-        .onTripleTap(dotColor: .gray, targetLabel: "fullscreen") {
-            onTapFullscreen()
+        .onTripleTap(dotColor: .gray, targetLabel: tripleClickAction == 0 ? "fullscreen" : "") {
+            if tripleClickAction == 0 {
+                onTapFullscreen()
+            }
         }
     }
 }

--- a/imujoco/app/app/simulation_grid_view.swift
+++ b/imujoco/app/app/simulation_grid_view.swift
@@ -462,6 +462,7 @@ struct SettingsView: View {
     @Binding var defaultView: Int
     var onDismiss: () -> Void
     @AppStorage("caffeineMode") private var caffeineMode: Int = 1  // 0=off, 1=half, 2=full
+    @AppStorage("tripleClickAction") private var tripleClickAction: Int = 0  // 0=grid/fullscreen, 1=lock/unlock
     @State private var showCaffeineInfo = false
 
     // tag 0 = grid, 1-4 = fullscreen instance (highlightedCell 0-3)
@@ -472,6 +473,24 @@ struct SettingsView: View {
         (2, 3),
         (3, 4),
     ]
+
+    private func tripleClickOption<Content: View>(tag: Int, @ViewBuilder content: () -> Content) -> some View {
+        Button(action: { tripleClickAction = tag }) {
+            content()
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(tripleClickAction == tag ? Color.blue.opacity(0.2) : Color.clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(tripleClickAction == tag ? Color.blue : Color.gray.opacity(0.3), lineWidth: tripleClickAction == tag ? 1.5 : 1)
+                )
+                .foregroundColor(tripleClickAction == tag ? .blue : .gray)
+        }
+        .buttonStyle(.plain)
+    }
 
     var body: some View {
         NavigationStack {
@@ -490,6 +509,37 @@ struct SettingsView: View {
                                 }
                                 .buttonStyle(.plain)
                                 .frame(maxWidth: .infinity)
+                            }
+                        }
+                    }
+                }
+
+                Section {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Triple Click")
+                            .font(.subheadline)
+                        HStack(spacing: 8) {
+                            tripleClickOption(tag: 0) {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                                    Text("fullscreen")
+                                    Text("↔")
+                                        .foregroundColor(.secondary)
+                                    Image(systemName: "arrow.down.right.and.arrow.up.left")
+                                    Text("grid")
+                                }
+                                .font(.system(size: 12))
+                            }
+                            tripleClickOption(tag: 1) {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "lock")
+                                    Text("lock")
+                                    Text("↔")
+                                        .foregroundColor(.secondary)
+                                    Image(systemName: "lock.open")
+                                    Text("unlock")
+                                }
+                                .font(.system(size: 12))
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Add a new "Triple Click" setting in Settings with two horizontal options: **fullscreen ↔ grid** (default) and **lock ↔ unlock**
- Grid cells and fullscreen view respect the chosen triple-click action
- Empty cells are inert in lock/unlock mode (no side effects)

## Test plan
- [x] Open Settings → verify "Triple Click" section appears between Default View and Caffeine Mode
- [x] With "fullscreen ↔ grid" selected: triple-click grid cell → fullscreen; triple-click fullscreen → grid
- [x] With "lock ↔ unlock" selected: triple-click grid cell → toggles lock; triple-click fullscreen → toggles lock
- [x] With "lock ↔ unlock" selected: triple-click empty grid cell → nothing happens
- [x] With "lock ↔ unlock" selected: triple-click empty fullscreen view → nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)