### PR TITLE
fix(ui): Settings view polish

### DIFF
--- a/imujoco/app/app/simulation_grid_view.swift
+++ b/imujoco/app/app/simulation_grid_view.swift
@@ -646,7 +646,7 @@ struct SettingsView: View {
                     NavigationLink {
                         AboutView()
                     } label: {
-                        Label("About", systemImage: "info.circle")
+                        Text("About iMuJoCo")
                     }
                     #if !os(tvOS)
                     .listRowSeparator(.visible, edges: .all)


### PR DESCRIPTION
## Summary
- Show Caffeine Mode info as a popover instead of inline expanding text, keeping the settings layout stable
- Rename "About" row to "About iMuJoCo" and remove the info.circle icon

## Test plan
- [x] Open Settings, tap the info button next to Caffeine Mode — popover appears with wrapped text
- [x] Dismiss popover — settings layout unchanged
- [x] Verify "About iMuJoCo" row at the bottom has no icon and navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)