### PR TITLE
feat: add Unitree H1 model

### DIFF
--- a/imujoco/app/BUILD.bazel
+++ b/imujoco/app/BUILD.bazel
@@ -60,6 +60,7 @@ apple_resource_group(
     name = "menagerie_models",
     structured_resources = [
         "@mujoco_menagerie//:unitree_g1",
+        "@mujoco_menagerie//:unitree_h1",
     ],
 )
 

--- a/imujoco/app/app/simulation_grid_view.swift
+++ b/imujoco/app/app/simulation_grid_view.swift
@@ -692,7 +692,7 @@ struct AboutView: View {
     private let modelInfo: [(name: String, source: String, license: String)] = [
         ("Car, Humanoid (Supine)", "MuJoCo", "Apache 2.0"),
         ("Simple Pendulum", "iMuJoCo", "Apache 2.0"),
-        ("Unitree G1", "Menagerie", "BSD-3"),
+        ("Unitree G1, Unitree H1", "Menagerie", "BSD-3"),
     ]
 
     var body: some View {

--- a/imujoco/app/app/simulation_manager.swift
+++ b/imujoco/app/app/simulation_manager.swift
@@ -391,6 +391,8 @@ final class SimulationGridManager: @unchecked Sendable {
                          keyframe: "start", timestep: nil, cameraElevation: nil, cameraAzimuth: nil, cameraDistance: nil),
             BundledModel(name: "Unitree G1", source: .menagerie, resource: "scene", subdirectory: "unitree_g1",
                          keyframe: nil, timestep: nil, cameraElevation: nil, cameraAzimuth: nil, cameraDistance: nil),
+            BundledModel(name: "Unitree H1", source: .menagerie, resource: "scene", subdirectory: "unitree_h1",
+                         keyframe: nil, timestep: nil, cameraElevation: nil, cameraAzimuth: nil, cameraDistance: nil),
         ]
     }
 

--- a/third_party/mujoco_menagerie.BUILD
+++ b/third_party/mujoco_menagerie.BUILD
@@ -14,3 +14,16 @@ filegroup(
         allow_empty = True,  # .stl/.STL: only one case matches per platform
     ),
 )
+
+filegroup(
+    name = "unitree_h1",
+    srcs = glob(
+        [
+            "unitree_h1/**/*.xml",
+            "unitree_h1/**/*.stl",
+            "unitree_h1/**/*.STL",
+            "unitree_h1/LICENSE",
+        ],
+        allow_empty = True,
+    ),
+)


### PR DESCRIPTION
## Summary
- Bundle the Unitree H1 humanoid robot model (BSD-3) from MuJoCo Menagerie
- Follows the same pattern as the existing Unitree G1 integration

## Test plan
- [ ] Open model picker, verify "Unitree H1" appears under Menagerie
- [ ] Load Unitree H1 — model renders and simulation runs
- [ ] Verify About screen lists both G1 and H1

🤖 Generated with [Claude Code](https://claude.com/claude-code)