### PR TITLE
feat: add ANYbotics ANYmal C model from Menagerie

### DIFF
--- a/imujoco/app/BUILD.bazel
+++ b/imujoco/app/BUILD.bazel
@@ -60,6 +60,7 @@ apple_resource_group(
     name = "menagerie_models",
     structured_resources = [
         "@mujoco_menagerie//:agility_cassie",
+        "@mujoco_menagerie//:anybotics_anymal_c",
         "@mujoco_menagerie//:unitree_g1",
         "@mujoco_menagerie//:unitree_h1",
     ],

--- a/imujoco/app/app/simulation_grid_view.swift
+++ b/imujoco/app/app/simulation_grid_view.swift
@@ -692,7 +692,7 @@ struct AboutView: View {
     private let modelInfo: [(name: String, source: String, license: String)] = [
         ("Car, Humanoid (Supine)", "MuJoCo", "Apache 2.0"),
         ("Simple Pendulum", "iMuJoCo", "Apache 2.0"),
-        ("Agility Cassie, Unitree G1, Unitree H1", "Menagerie", "BSD-3"),
+        ("Agility Cassie, ANYmal C, Unitree G1, Unitree H1", "Menagerie", "BSD-3"),
     ]
 
     var body: some View {

--- a/imujoco/app/app/simulation_manager.swift
+++ b/imujoco/app/app/simulation_manager.swift
@@ -394,6 +394,8 @@ final class SimulationGridManager: @unchecked Sendable {
                          keyframe: "start", timestep: nil, cameraElevation: nil, cameraAzimuth: nil, cameraDistance: nil),
             BundledModel(name: "Agility Cassie", source: .menagerie, resource: "scene", subdirectory: "agility_cassie",
                          keyframe: "home", timestep: nil, cameraElevation: nil, cameraAzimuth: nil, cameraDistance: nil),
+            BundledModel(name: "ANYmal C", source: .menagerie, resource: "scene", subdirectory: "anybotics_anymal_c",
+                         keyframe: nil, timestep: nil, cameraElevation: nil, cameraAzimuth: nil, cameraDistance: nil),
             BundledModel(name: "Unitree G1", source: .menagerie, resource: "scene", subdirectory: "unitree_g1",
                          keyframe: nil, timestep: nil, cameraElevation: nil, cameraAzimuth: nil, cameraDistance: nil),
             BundledModel(name: "Unitree H1", source: .menagerie, resource: "scene", subdirectory: "unitree_h1",

--- a/third_party/mujoco_menagerie.BUILD
+++ b/third_party/mujoco_menagerie.BUILD
@@ -26,6 +26,16 @@ filegroup(
 )
 
 filegroup(
+    name = "anybotics_anymal_c",
+    srcs = glob([
+        "anybotics_anymal_c/**/*.xml",
+        "anybotics_anymal_c/**/*.obj",
+        "anybotics_anymal_c/**/*.png",
+        "anybotics_anymal_c/LICENSE",
+    ]),
+)
+
+filegroup(
     name = "unitree_h1",
     srcs = glob(
         [


### PR DESCRIPTION
## Summary
- Add ANYbotics ANYmal C quadruped robot from MuJoCo Menagerie
- Model includes OBJ meshes with per-part PNG textures (rendered via the texture pipeline from #64)

## Test plan
- [x] Load ANYmal C → textured quadruped renders correctly
- [x] Existing models (Car, Humanoid, Cassie, G1, H1) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)