### PR TITLE
feat: add 100 Humanoids benchmark model

### DIFF
--- a/imujoco/app/app/simulation_manager.swift
+++ b/imujoco/app/app/simulation_manager.swift
@@ -390,6 +390,8 @@ final class SimulationGridManager: @unchecked Sendable {
                          keyframe: nil, timestep: nil, cameraElevation: nil, cameraAzimuth: nil, cameraDistance: nil),
             BundledModel(name: "Humanoid (Supine)", source: .mujoco, resource: "humanoid_supine", subdirectory: nil,
                          keyframe: "supine", timestep: nil, cameraElevation: nil, cameraAzimuth: nil, cameraDistance: nil),
+            BundledModel(name: "100 Humanoids", source: .mujoco, resource: "100_humanoids", subdirectory: "model/humanoid",
+                         keyframe: nil, timestep: nil, cameraElevation: nil, cameraAzimuth: nil, cameraDistance: nil),
             BundledModel(name: "Simple Pendulum", source: .imujoco, resource: "simple_pendulum", subdirectory: nil,
                          keyframe: "start", timestep: nil, cameraElevation: nil, cameraAzimuth: nil, cameraDistance: nil),
             BundledModel(name: "Agility Cassie", source: .menagerie, resource: "scene", subdirectory: "agility_cassie",

--- a/third_party/mujoco.BUILD
+++ b/third_party/mujoco.BUILD
@@ -112,6 +112,6 @@ filegroup(
 
 filegroup(
     name = "humanoid_model",
-    srcs = ["model/humanoid/humanoid.xml"],
+    srcs = glob(["model/humanoid/*.xml"]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## Summary
- Add MuJoCo's 100 Humanoids benchmark model (10×10 grid using `<replicate>`)
- Great stress test for physics + rendering performance on device

## Test plan
- [ ] Load 100 Humanoids → all 100 humanoids render and simulate
- [ ] Existing models unchanged
- [ ] Check FPS on target devices (iPhone 16e, iPad, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)