### PR TITLE
fix: guard insetGrouped list style to iOS only

### DIFF
--- a/imujoco/app/app/simulation_grid_view.swift
+++ b/imujoco/app/app/simulation_grid_view.swift
@@ -315,7 +315,11 @@ struct ModelPickerView: View {
                 }
             }
             .navigationTitle("Select Model")
+            #if os(iOS)
             .listStyle(.insetGrouped)
+            #elseif os(tvOS)
+            .listStyle(.grouped)
+            #endif
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif


### PR DESCRIPTION
## Summary
- `.listStyle(.insetGrouped)` from #67 is unavailable on tvOS and macOS
- Use `.grouped` on tvOS, default on macOS

## Test plan
- [x] `bazel build //...` passes all 32 targets (iOS, tvOS, macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)