### PR TITLE
fix: provisioning profile config and security hardening

### DIFF
--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -1,0 +1,35 @@
+name: Secrets Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for team_config.bzl
+        run: |
+          if [ -f imujoco/app/team_config.bzl ]; then
+            echo "::error::team_config.bzl must not be committed (contains developer-specific secrets)"
+            exit 1
+          fi
+
+      - name: Check for provisioning profiles
+        run: |
+          if find . -name "*.mobileprovision" | grep -q .; then
+            echo "::error::Provisioning profiles must not be committed"
+            exit 1
+          fi
+
+      - name: Check for hardcoded team IDs in tracked files
+        run: |
+          # Search for common Apple Team ID patterns (10-char alphanumeric) in build files
+          # Exclude template files and this workflow
+          if grep -rn "DEVELOPMENT_TEAM = [A-Z0-9]\{10\}" --include="*.pbxproj" .; then
+            echo "::error::Hardcoded DEVELOPMENT_TEAM found in tracked files"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ iMuJoCo/
 ```bash
 git clone https://github.com/hhkblogi/iMuJoCo.git
 cd iMuJoCo
+git config core.hooksPath .githooks
 ```
 
 ### Build

--- a/imujoco/app/BUILD.bazel
+++ b/imujoco/app/BUILD.bazel
@@ -5,7 +5,7 @@ load("@rules_apple//apple:macos.bzl", "macos_application")
 load("@rules_apple//apple:resources.bzl", "apple_resource_group")
 load("@rules_apple//apple:tvos.bzl", "tvos_application")
 load("@rules_xcodeproj//xcodeproj:xcode_provisioning_profile.bzl", "xcode_provisioning_profile")
-load(":team_config.bzl", "APPSTORE_PROFILE_NAME", "TEAM_ID")
+load(":team_config.bzl", "APPSTORE_PROFILE_NAME", "DEV_PROFILE_NAME", "TEAM_ID")
 
 # ============================================================================
 # App Swift library
@@ -41,7 +41,7 @@ swift_library(
 
 local_provisioning_profile(
     name = "local_profile",
-    profile_name = "iOS Team Provisioning Profile: *",
+    profile_name = DEV_PROFILE_NAME,
     team_id = TEAM_ID,
 )
 

--- a/imujoco/app/team_config.bzl.template
+++ b/imujoco/app/team_config.bzl.template
@@ -4,5 +4,8 @@
 
 TEAM_ID = "YOUR_TEAM_ID_HERE"
 
+# Development provisioning profile name (shown in Apple Developer portal)
+DEV_PROFILE_NAME = "iOS Team Provisioning Profile: *"
+
 # App Store distribution provisioning profile name (shown in Apple Developer portal)
 APPSTORE_PROFILE_NAME = "YOUR_APPSTORE_PROFILE_NAME_HERE"


### PR DESCRIPTION
## Summary
- Move `DEV_PROFILE_NAME` to `team_config.bzl` (gitignored) so profile names aren't hardcoded in tracked files
- Add `git config core.hooksPath .githooks` to README clone instructions
- Add GitHub Actions secrets check workflow to catch accidental commits of:
  - `team_config.bzl`
  - `*.mobileprovision` files
  - Hardcoded `DEVELOPMENT_TEAM` in `.pbxproj` files

## Test plan
- [x] `bazel build //imujoco/app:app` passes
- [x] Xcode install works on all registered devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)