### PR TITLE
feat: unify RTP/RTSP to same port, add HEVC receiver app

### DIFF
--- a/driver/BUILD.bazel
+++ b/driver/BUILD.bazel
@@ -151,3 +151,21 @@ macos_application(
     minimum_os_version = "26.0",
     deps = [":quic_receiver_lib"],
 )
+
+# ============================================================================
+# HEVC/RTP Video Receiver (macOS SwiftUI app)
+# ============================================================================
+
+swift_library(
+    name = "hevc_receiver_lib",
+    srcs = glob(["hevc/*.swift"]),
+    module_name = "HevcReceiver",
+)
+
+macos_application(
+    name = "hevc_receiver",
+    bundle_id = "com.imujoco.hevc-receiver",
+    infoplists = ["hevc/Info.plist"],
+    minimum_os_version = "26.0",
+    deps = [":hevc_receiver_lib"],
+)

--- a/driver/hevc/HevcReceiverApp.swift
+++ b/driver/hevc/HevcReceiverApp.swift
@@ -1,0 +1,37 @@
+// HevcReceiverApp.swift
+// macOS SwiftUI app for receiving HEVC-over-RTP video from iMuJoCo.
+//
+// Usage:
+//   HevcReceiver --host <ip> --port <port>
+//   Defaults: localhost:9100
+
+import SwiftUI
+
+@main
+struct HevcReceiverApp: App {
+    var body: some Scene {
+        WindowGroup {
+            HevcReceiverView(host: Self.host, port: Self.port)
+                .frame(minWidth: 480, minHeight: 360)
+        }
+        .defaultSize(width: 640, height: 520)
+    }
+
+    // MARK: - CLI Arguments
+
+    private static var host: String {
+        let args = CommandLine.arguments
+        if let idx = args.firstIndex(of: "--host"), idx + 1 < args.count {
+            return args[idx + 1]
+        }
+        return "localhost"
+    }
+
+    private static var port: UInt16 {
+        let args = CommandLine.arguments
+        if let idx = args.firstIndex(of: "--port"), idx + 1 < args.count {
+            return UInt16(args[idx + 1]) ?? 9100
+        }
+        return 9100
+    }
+}

--- a/driver/hevc/HevcReceiverView.swift
+++ b/driver/hevc/HevcReceiverView.swift
@@ -1,0 +1,129 @@
+// HevcReceiverView.swift
+// Main view: video feed with latency stats overlay.
+
+import SwiftUI
+
+struct HevcReceiverView: View {
+    @State private var client = HevcVideoClient()
+    @State private var host: String
+    @State private var port: String
+
+    init(host: String = "localhost", port: UInt16 = 9100) {
+        _host = State(initialValue: host)
+        _port = State(initialValue: String(port))
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            // Video frame
+            if let frame = client.currentFrame {
+                Image(decorative: frame, scale: 1.0)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                VStack(spacing: 16) {
+                    Image(systemName: "video.slash")
+                        .font(.system(size: 48))
+                        .foregroundColor(.gray)
+                    Text("No video signal")
+                        .foregroundColor(.gray)
+                }
+            }
+
+            // Stats overlay (top-right)
+            VStack {
+                HStack {
+                    Spacer()
+                    statsOverlay
+                }
+                Spacer()
+            }
+            .padding()
+
+            // Connection controls (bottom)
+            VStack {
+                Spacer()
+                connectionBar
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Stats Overlay
+
+    private var statsOverlay: some View {
+        VStack(alignment: .trailing, spacing: 4) {
+            if client.isConnected {
+                Text("Frame #\(client.stats.frameNumber)")
+                    .font(.system(size: 11, design: .monospaced))
+                Text(String(format: "Sim Time: %.3fs", client.stats.simulationTime))
+                    .font(.system(size: 11, design: .monospaced))
+                Text(String(format: "Decode: %.1fms", client.stats.decodeLatencyMs))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(client.stats.decodeLatencyMs < 10 ? .green : .yellow)
+                Text("Received: \(client.stats.framesReceived)")
+                    .font(.system(size: 11, design: .monospaced))
+                Text("Decoded: \(client.stats.framesDecoded)")
+                    .font(.system(size: 11, design: .monospaced))
+                if client.stats.framesDropped > 0 {
+                    Text("Dropped: \(client.stats.framesDropped)")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(.red)
+                }
+            }
+        }
+        .foregroundColor(.white.opacity(0.9))
+        .padding(8)
+        .background(Color.black.opacity(0.6))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    // MARK: - Connection Bar
+
+    private var connectionBar: some View {
+        HStack(spacing: 12) {
+            // Status indicator
+            Circle()
+                .fill(client.isConnected ? Color.green : client.isConnecting ? Color.yellow : Color.red)
+                .frame(width: 10, height: 10)
+
+            Text(client.connectionStatus)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(.white.opacity(0.8))
+                .lineLimit(1)
+
+            Spacer()
+
+            // Host:Port fields
+            TextField("Host", text: $host)
+                .font(.system(size: 12, design: .monospaced))
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 140)
+
+            TextField("Port", text: $port)
+                .font(.system(size: 12, design: .monospaced))
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 60)
+
+            // Connect/Disconnect/Cancel button
+            Button(action: {
+                if client.isConnected || client.isConnecting {
+                    client.disconnect()
+                } else {
+                    let portNum = UInt16(port) ?? 9100
+                    client.connect(host: host, port: portNum)
+                }
+            }) {
+                Text(client.isConnected ? "Disconnect" : client.isConnecting ? "Cancel" : "Connect")
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(client.isConnected ? .red : client.isConnecting ? .orange : .blue)
+        }
+        .padding(10)
+        .background(Color.black.opacity(0.7))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}

--- a/driver/hevc/HevcVideoClient.swift
+++ b/driver/hevc/HevcVideoClient.swift
@@ -1,0 +1,740 @@
+// HevcVideoClient.swift
+// HEVC/RTP video receiver client using Network.framework.
+// Connects to the iMuJoCo RTSP server, negotiates RTP transport,
+// receives HEVC frames via RTP (RFC 7798), decodes via VideoToolbox
+// hardware decoder, and publishes CGImage frames.
+//
+// RTSP negotiation (TCP):
+//   Client → Server: OPTIONS / DESCRIBE / SETUP / PLAY / TEARDOWN
+// RTP data (UDP):
+//   Server → Client: RTP packets with HEVC NAL payloads (single or FU)
+
+import CoreGraphics
+import CoreImage
+import CoreVideo
+import Foundation
+import Network
+import VideoToolbox
+import os.log
+
+private let logger = Logger(subsystem: "com.imujoco.hevc-receiver", category: "HevcVideoClient")
+
+// MARK: - Latency Stats
+
+struct LatencyStats {
+    var frameNumber: UInt64 = 0
+    var simulationTime: Double = 0
+    var decodeLatencyMs: Double = 0
+    var receiveTimestamp: Double = 0
+    var framesReceived: UInt64 = 0
+    var framesDecoded: UInt64 = 0
+    var framesDropped: UInt64 = 0
+}
+
+// MARK: - HEVC Video Client
+
+@Observable
+final class HevcVideoClient {
+    // Published state
+    private(set) var currentFrame: CGImage?
+    private(set) var stats = LatencyStats()
+    private(set) var isConnecting = false
+    private(set) var isConnected = false
+    private(set) var connectionStatus: String = "Disconnected"
+
+    // RTSP state
+    private var rtspConnection: NWConnection?
+    private var rtspSessionId: String?
+    private var cseq: Int = 0
+    private let queue = DispatchQueue(label: "com.imujoco.hevc-receiver.network", qos: .userInitiated)
+
+    // RTP state (outgoing NWConnection to server's RTP/UDP port)
+    private var rtpConnection: NWConnection?
+    private var rtpPort: UInt16 = 0
+
+    // RTP depacketization — pre-allocated buffers
+    private var nalAssemblyBuffer = Data(capacity: 256 * 1024)
+    private var frameBuffer = Data(capacity: 256 * 1024)
+    private var currentTimestamp: UInt32 = 0
+    private var assemblingFU = false
+
+    // Video decode
+    private var decompressionSession: VTDecompressionSession?
+    private var formatDescription: CMVideoFormatDescription?
+    private let ciContext = CIContext(options: [.useSoftwareRenderer: false])
+
+    // HEVC parameter sets
+    private var vps: Data?
+    private var sps: Data?
+    private var pps: Data?
+
+    // MARK: - Connect
+
+    func connect(host: String, port: UInt16) {
+        disconnect()
+
+        isConnecting = true
+        connectionStatus = "Connecting to \(host):\(port)..."
+
+        // Create outgoing UDP connection to the server's RTP port.
+        // RTP and RTSP share the same port number (UDP vs TCP).
+        // Using NWConnection (outgoing) avoids macOS firewall blocking
+        // incoming UDP that NWListener would require.
+        let endpoint = NWEndpoint.hostPort(
+            host: NWEndpoint.Host(host),
+            port: NWEndpoint.Port(rawValue: port)!
+        )
+        let rtpConn = NWConnection(to: endpoint, using: .udp)
+        self.rtpConnection = rtpConn
+
+        rtpConn.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                // Send a register byte to establish the bidirectional UDP flow
+                // and trigger local port assignment.
+                rtpConn.send(content: Data([0x00]), completion: .contentProcessed { [weak self] _ in
+                    guard let self else { return }
+
+                    // Extract OS-assigned local port
+                    if let localEndpoint = rtpConn.currentPath?.localEndpoint,
+                       case .hostPort(_, let p) = localEndpoint {
+                        self.rtpPort = p.rawValue
+                    }
+                    logger.info("RTP connection ready, local port \(self.rtpPort)")
+
+                    // Start receiving RTP packets
+                    self.receiveRTPLoop(rtpConn)
+
+                    // Start RTSP negotiation
+                    self.startRTSP(host: host, port: port)
+                })
+
+            case .failed(let error):
+                logger.error("RTP connection failed: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    self.connectionStatus = "RTP connection failed"
+                }
+            default:
+                break
+            }
+        }
+
+        rtpConn.start(queue: queue)
+    }
+
+    func disconnect() {
+        // Send TEARDOWN if we have a session
+        if let conn = rtspConnection, let sessionId = rtspSessionId {
+            sendRTSPTeardown(conn: conn, sessionId: sessionId)
+        }
+
+        rtspTimeoutWork?.cancel()
+        rtspTimeoutWork = nil
+        rtspConnection?.cancel()
+        rtspConnection = nil
+        rtspSessionId = nil
+        cseq = 0
+
+        rtpConnection?.cancel()
+        rtpConnection = nil
+        rtpPort = 0
+
+        decompressionSession = nil
+        formatDescription = nil
+        vps = nil
+        sps = nil
+        pps = nil
+
+        nalAssemblyBuffer.removeAll(keepingCapacity: true)
+        frameBuffer.removeAll(keepingCapacity: true)
+        currentTimestamp = 0
+        assemblingFU = false
+
+        isConnecting = false
+        isConnected = false
+        connectionStatus = "Disconnected"
+    }
+
+    // MARK: - RTP Receive Loop
+
+    private func receiveRTPLoop(_ conn: NWConnection) {
+        conn.receiveMessage { [weak self] data, _, _, error in
+            guard let self else { return }
+
+            if let error {
+                logger.debug("RTP receive error: \(error.localizedDescription)")
+                return
+            }
+
+            if let data, data.count >= 12 {
+                self.processRTPPacket(data)
+            }
+
+            // Continue receiving (isComplete is always true for UDP datagrams)
+            if self.rtpConnection != nil {
+                self.receiveRTPLoop(conn)
+            }
+        }
+    }
+
+    // MARK: - RTP Depacketization (RFC 7798)
+
+    private func processRTPPacket(_ packet: Data) {
+        // Parse 12-byte RTP header by offset (zero-copy)
+        guard packet.count >= 12 else { return }
+
+        let byte0 = packet.withUnsafeBytes { $0.load(fromByteOffset: 0, as: UInt8.self) }
+        let version = (byte0 >> 6) & 0x03
+        guard version == 2 else { return }
+
+        let byte1 = packet.withUnsafeBytes { $0.load(fromByteOffset: 1, as: UInt8.self) }
+        let marker = (byte1 & 0x80) != 0
+
+        let timestamp = packet.withUnsafeBytes {
+            CFSwapInt32BigToHost($0.loadUnaligned(fromByteOffset: 4, as: UInt32.self))
+        }
+
+        let payloadOffset = 12
+        let payloadLength = packet.count - payloadOffset
+        guard payloadLength >= 2 else { return }
+
+        // If timestamp changed, we have a new frame — flush previous
+        if timestamp != currentTimestamp && !frameBuffer.isEmpty {
+            decodeFrame(timestamp: currentTimestamp)
+            frameBuffer.removeAll(keepingCapacity: true)
+            assemblingFU = false
+        }
+        currentTimestamp = timestamp
+
+        // Read HEVC NAL header (2 bytes) from payload
+        let nalByte0 = packet.withUnsafeBytes { $0.load(fromByteOffset: payloadOffset, as: UInt8.self) }
+        let nalType = (nalByte0 >> 1) & 0x3F
+
+        if nalType == 49 {
+            // Fragmentation Unit (FU) — RFC 7798 §4.4.3
+            guard payloadLength >= 3 else { return }
+
+            let fuHeader = packet.withUnsafeBytes { $0.load(fromByteOffset: payloadOffset + 2, as: UInt8.self) }
+            let startBit = (fuHeader & 0x80) != 0
+            let endBit = (fuHeader & 0x40) != 0
+            let fuType = fuHeader & 0x3F
+
+            let fuPayloadOffset = payloadOffset + 3
+            let fuPayloadLength = packet.count - fuPayloadOffset
+            guard fuPayloadLength > 0 else { return }
+
+            if startBit {
+                // Start fragment — reconstruct 2-byte NAL header
+                nalAssemblyBuffer.removeAll(keepingCapacity: true)
+
+                let nalByte1 = packet.withUnsafeBytes { $0.load(fromByteOffset: payloadOffset + 1, as: UInt8.self) }
+                // Reconstruct: forbidden(1) | fuType(6) | layerID_hi(1), layerID_lo(5) | tid(3)
+                let reconstructedByte0 = (nalByte0 & 0x81) | (fuType << 1)
+                nalAssemblyBuffer.append(reconstructedByte0)
+                nalAssemblyBuffer.append(nalByte1)
+
+                // Append FU payload
+                packet.withUnsafeBytes { rawBuf in
+                    nalAssemblyBuffer.append(rawBuf.baseAddress!.advanced(by: fuPayloadOffset).assumingMemoryBound(to: UInt8.self), count: fuPayloadLength)
+                }
+                assemblingFU = true
+
+            } else if assemblingFU {
+                // Middle or end fragment — append FU payload
+                packet.withUnsafeBytes { rawBuf in
+                    nalAssemblyBuffer.append(rawBuf.baseAddress!.advanced(by: fuPayloadOffset).assumingMemoryBound(to: UInt8.self), count: fuPayloadLength)
+                }
+
+                if endBit {
+                    // End fragment — flush assembled NAL to frameBuffer
+                    appendNALToFrameBuffer(nalAssemblyBuffer)
+                    nalAssemblyBuffer.removeAll(keepingCapacity: true)
+                    assemblingFU = false
+                }
+            }
+
+        } else if nalType >= 1 && nalType <= 47 {
+            // Single NAL Unit Packet — entire NAL fits in one RTP packet
+            // Payload is the raw NAL unit (including 2-byte header)
+            let nalData = packet.subdata(in: payloadOffset..<packet.count)
+            appendNALToFrameBuffer(nalData)
+        }
+
+        // Frame boundary: marker bit means all NALs for this timestamp received
+        if marker && !frameBuffer.isEmpty {
+            decodeFrame(timestamp: timestamp)
+            frameBuffer.removeAll(keepingCapacity: true)
+            assemblingFU = false
+        }
+    }
+
+    /// Append a NAL unit to frameBuffer in HVCC format (4-byte BE length prefix + NAL data)
+    private func appendNALToFrameBuffer(_ nalData: Data) {
+        var lengthBE = CFSwapInt32HostToBig(UInt32(nalData.count))
+        withUnsafeBytes(of: &lengthBE) { frameBuffer.append(contentsOf: $0) }
+        frameBuffer.append(nalData)
+    }
+
+    // MARK: - HEVC Decode
+
+    /// Decode a complete frame from frameBuffer (HVCC format: 4-byte length + NAL data).
+    /// Mirrors the QUIC receiver's decodeHEVC — offset-based NAL parsing, single CMBlockBuffer copy.
+    private func decodeFrame(timestamp: UInt32) {
+        let decodeStart = ProcessInfo.processInfo.systemUptime
+        let receiveTime = decodeStart
+
+        // Parse HVCC NAL units from frameBuffer to extract VPS/SPS/PPS
+        var nalOffset = 0
+        let bufferSize = frameBuffer.count
+
+        while nalOffset + 4 < bufferSize {
+            let nalSize = frameBuffer.withUnsafeBytes {
+                CFSwapInt32BigToHost($0.loadUnaligned(fromByteOffset: nalOffset, as: UInt32.self))
+            }
+
+            guard nalSize > 0, nalOffset + 4 + Int(nalSize) <= bufferSize else { break }
+
+            let nalDataOffset = nalOffset + 4
+
+            // Read NAL type byte directly — no copy needed
+            let nalTypeByte = frameBuffer.withUnsafeBytes {
+                $0.load(fromByteOffset: nalDataOffset, as: UInt8.self)
+            }
+            let nalType = (nalTypeByte >> 1) & 0x3F
+
+            // Only copy VPS/SPS/PPS (small, extracted once)
+            switch nalType {
+            case 32: vps = frameBuffer.subdata(in: nalDataOffset..<nalDataOffset + Int(nalSize))
+            case 33: sps = frameBuffer.subdata(in: nalDataOffset..<nalDataOffset + Int(nalSize))
+            case 34: pps = frameBuffer.subdata(in: nalDataOffset..<nalDataOffset + Int(nalSize))
+            default: break
+            }
+
+            nalOffset += 4 + Int(nalSize)
+        }
+
+        // Create format description if we have parameter sets
+        if let vps, let sps, let pps, formatDescription == nil {
+            createFormatDescription(vps: vps, sps: sps, pps: pps)
+        }
+
+        guard let formatDesc = formatDescription else {
+            logger.debug("Waiting for parameter sets (VPS/SPS/PPS)")
+            return
+        }
+
+        let hevcLength = frameBuffer.count
+
+        // Create CMBlockBuffer: single alloc, copy directly from frameBuffer
+        var blockBuffer: CMBlockBuffer?
+        var status = CMBlockBufferCreateWithMemoryBlock(
+            allocator: kCFAllocatorDefault,
+            memoryBlock: nil,
+            blockLength: hevcLength,
+            blockAllocator: nil,
+            customBlockSource: nil,
+            offsetToData: 0,
+            dataLength: hevcLength,
+            flags: 0,
+            blockBufferOut: &blockBuffer
+        )
+
+        guard status == kCMBlockBufferNoErr, let blockBuf = blockBuffer else {
+            logger.error("Failed to create CMBlockBuffer: \(status)")
+            return
+        }
+
+        // Single copy: frameBuffer → CMBlockBuffer
+        status = frameBuffer.withUnsafeBytes { rawPtr in
+            CMBlockBufferReplaceDataBytes(
+                with: rawPtr.baseAddress!,
+                blockBuffer: blockBuf,
+                offsetIntoDestination: 0,
+                dataLength: hevcLength
+            )
+        }
+
+        guard status == kCMBlockBufferNoErr else {
+            logger.error("Failed to copy data into CMBlockBuffer: \(status)")
+            return
+        }
+
+        // Derive frame number and simulation time from RTP timestamp (90kHz clock)
+        let simulationTime = Double(timestamp) / 90000.0
+        let frameNumber = stats.framesReceived
+
+        var sampleBuffer: CMSampleBuffer?
+        var timingInfo = CMSampleTimingInfo(
+            duration: CMTime(value: 1, timescale: 30),
+            presentationTimeStamp: CMTime(value: CMTimeValue(timestamp), timescale: 90000),
+            decodeTimeStamp: .invalid
+        )
+
+        let sampleStatus = CMSampleBufferCreateReady(
+            allocator: kCFAllocatorDefault,
+            dataBuffer: blockBuf,
+            formatDescription: formatDesc,
+            sampleCount: 1,
+            sampleTimingEntryCount: 1,
+            sampleTimingArray: &timingInfo,
+            sampleSizeEntryCount: 1,
+            sampleSizeArray: [hevcLength],
+            sampleBufferOut: &sampleBuffer
+        )
+
+        guard sampleStatus == noErr, let sampleBuffer else {
+            logger.error("Failed to create CMSampleBuffer: \(sampleStatus)")
+            return
+        }
+
+        if decompressionSession == nil {
+            createDecompressionSession(formatDescription: formatDesc)
+        }
+
+        guard let session = decompressionSession else { return }
+
+        var flagsOut = VTDecodeInfoFlags()
+        let decodeStatus = VTDecompressionSessionDecodeFrame(
+            session,
+            sampleBuffer: sampleBuffer,
+            flags: [._EnableAsynchronousDecompression],
+            infoFlagsOut: &flagsOut
+        ) { [weak self] (status: OSStatus, _: VTDecodeInfoFlags, imageBuffer: CVImageBuffer?, _: [CMTaggedBuffer]?, _: CMTime, _: CMTime) in
+            guard let self else { return }
+            if status != noErr {
+                logger.debug("Decode callback error: \(status)")
+                DispatchQueue.main.async { self.stats.framesDropped += 1 }
+                return
+            }
+            guard let pixelBuffer = imageBuffer else { return }
+            self.handleDecodedFrame(pixelBuffer)
+        }
+
+        if decodeStatus != noErr {
+            logger.error("VTDecompressionSessionDecodeFrame failed: \(decodeStatus)")
+            DispatchQueue.main.async { self.stats.framesDropped += 1 }
+            return
+        }
+
+        VTDecompressionSessionWaitForAsynchronousFrames(session)
+
+        // Batched stats update — single dispatch
+        let decodeMs = (ProcessInfo.processInfo.systemUptime - decodeStart) * 1000
+        DispatchQueue.main.async {
+            self.stats.framesReceived += 1
+            self.stats.frameNumber = frameNumber + 1
+            self.stats.simulationTime = simulationTime
+            self.stats.receiveTimestamp = receiveTime
+            self.stats.decodeLatencyMs = decodeMs
+            self.stats.framesDecoded += 1
+        }
+    }
+
+    private func createFormatDescription(vps: Data, sps: Data, pps: Data) {
+        let parameterSets: [Data] = [vps, sps, pps]
+        let sizes = parameterSets.map { $0.count }
+
+        var formatDesc: CMVideoFormatDescription?
+
+        let status = parameterSets.withUnsafeBufferPointers { ptrs in
+            CMVideoFormatDescriptionCreateFromHEVCParameterSets(
+                allocator: kCFAllocatorDefault,
+                parameterSetCount: 3,
+                parameterSetPointers: ptrs,
+                parameterSetSizes: sizes,
+                nalUnitHeaderLength: 4,
+                extensions: nil,
+                formatDescriptionOut: &formatDesc
+            )
+        }
+
+        if status == noErr, let formatDesc {
+            self.formatDescription = formatDesc
+            logger.info("Created HEVC format description")
+        } else {
+            logger.error("Failed to create HEVC format description: \(status)")
+        }
+    }
+
+    private func createDecompressionSession(formatDescription: CMVideoFormatDescription) {
+        let attributes: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        ]
+
+        var session: VTDecompressionSession?
+        let status = VTDecompressionSessionCreate(
+            allocator: kCFAllocatorDefault,
+            formatDescription: formatDescription,
+            decoderSpecification: nil,
+            imageBufferAttributes: attributes as CFDictionary,
+            outputCallback: nil,
+            decompressionSessionOut: &session
+        )
+
+        if status == noErr, let session {
+            self.decompressionSession = session
+            logger.info("Created VTDecompressionSession")
+        } else {
+            logger.error("Failed to create VTDecompressionSession: \(status)")
+        }
+    }
+
+    /// Convert decoded pixel buffer to CGImage via GPU-accelerated CIContext.
+    private func handleDecodedFrame(_ pixelBuffer: CVPixelBuffer) {
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        guard let cgImage = ciContext.createCGImage(ciImage, from: ciImage.extent) else { return }
+        DispatchQueue.main.async {
+            self.currentFrame = cgImage
+        }
+    }
+
+    // MARK: - RTSP Negotiation (TCP) with Auto-Retry
+
+    private static let rtspRetryInterval: TimeInterval = 2.0
+    private static let rtspConnectTimeout: TimeInterval = 3.0
+    private var rtspTimeoutWork: DispatchWorkItem?
+
+    private func startRTSP(host: String, port: UInt16) {
+        // Clean up previous RTSP connection if retrying
+        rtspTimeoutWork?.cancel()
+        rtspTimeoutWork = nil
+        rtspConnection?.cancel()
+        rtspConnection = nil
+        rtspSessionId = nil
+        cseq = 0
+
+        // Don't retry if user cancelled
+        guard isConnecting else { return }
+
+        DispatchQueue.main.async {
+            self.connectionStatus = "Connecting to \(host):\(port)..."
+        }
+
+        let endpoint = NWEndpoint.hostPort(
+            host: NWEndpoint.Host(host),
+            port: NWEndpoint.Port(rawValue: port)!
+        )
+
+        let conn = NWConnection(to: endpoint, using: .tcp)
+        rtspConnection = conn
+
+        // Timeout: if TCP doesn't connect within a few seconds, cancel and retry
+        let timeout = DispatchWorkItem { [weak self] in
+            guard let self, self.isConnecting, self.rtspConnection === conn else { return }
+            conn.cancel()
+            self.retryRTSP(host: host, port: port, reason: "Server unreachable")
+        }
+        rtspTimeoutWork = timeout
+        queue.asyncAfter(deadline: .now() + Self.rtspConnectTimeout, execute: timeout)
+
+        conn.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                // Connected — cancel timeout
+                self.rtspTimeoutWork?.cancel()
+                self.rtspTimeoutWork = nil
+                logger.info("RTSP TCP connection ready")
+                self.sendRTSPOptions(conn: conn, host: host, port: port)
+            case .failed:
+                self.rtspTimeoutWork?.cancel()
+                self.rtspTimeoutWork = nil
+                self.retryRTSP(host: host, port: port, reason: "Connection failed")
+            case .cancelled:
+                break
+            default:
+                break
+            }
+        }
+
+        conn.start(queue: queue)
+    }
+
+    private func retryRTSP(host: String, port: UInt16, reason: String) {
+        guard isConnecting else { return }
+        let delay = Self.rtspRetryInterval
+        logger.info("RTSP: \(reason), retrying in \(delay)s...")
+        DispatchQueue.main.async {
+            self.connectionStatus = "\(reason) — retrying..."
+        }
+        queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.startRTSP(host: host, port: port)
+        }
+    }
+
+    // MARK: - RTSP Request Helpers
+
+    private func nextCSeq() -> Int {
+        cseq += 1
+        return cseq
+    }
+
+    private func sendRTSPRequest(_ conn: NWConnection, method: String, uri: String,
+                                  extraHeaders: String = "", completion: @escaping (String?) -> Void) {
+        let seq = nextCSeq()
+        let request = "\(method) \(uri) RTSP/1.0\r\nCSeq: \(seq)\r\n\(extraHeaders)\r\n"
+
+        conn.send(content: Data(request.utf8), completion: .contentProcessed { error in
+            if let error {
+                logger.error("Failed to send \(method): \(error.localizedDescription)")
+                completion(nil)
+                return
+            }
+        })
+
+        // Receive response
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 8192) { data, _, _, error in
+            if let error {
+                logger.error("Failed to receive \(method) response: \(error.localizedDescription)")
+                completion(nil)
+                return
+            }
+            guard let data, let response = String(data: data, encoding: .utf8) else {
+                completion(nil)
+                return
+            }
+            completion(response)
+        }
+    }
+
+    private func parseRTSPStatusCode(_ response: String) -> Int? {
+        // First line: "RTSP/1.0 200 OK"
+        guard let firstLine = response.split(separator: "\r\n", maxSplits: 1).first else { return nil }
+        let parts = firstLine.split(separator: " ", maxSplits: 2)
+        guard parts.count >= 2, let code = Int(parts[1]) else { return nil }
+        return code
+    }
+
+    private func parseRTSPHeader(_ response: String, name: String) -> String? {
+        let lines = response.split(separator: "\r\n")
+        let prefix = name + ": "
+        for line in lines {
+            if line.hasPrefix(prefix) {
+                return String(line.dropFirst(prefix.count))
+            }
+        }
+        return nil
+    }
+
+    // MARK: - RTSP Sequence: OPTIONS → DESCRIBE → SETUP → PLAY
+
+    private func sendRTSPOptions(conn: NWConnection, host: String, port: UInt16) {
+        let uri = "rtsp://\(host):\(port)/camera0"
+
+        sendRTSPRequest(conn, method: "OPTIONS", uri: uri) { [weak self] response in
+            guard let self, let response else {
+                self?.failRTSP("OPTIONS failed", host: host, port: port)
+                return
+            }
+            guard let status = self.parseRTSPStatusCode(response), status == 200 else {
+                self.failRTSP("OPTIONS rejected", host: host, port: port)
+                return
+            }
+            logger.info("RTSP OPTIONS OK")
+            self.sendRTSPDescribe(conn: conn, host: host, port: port, uri: uri)
+        }
+    }
+
+    private func sendRTSPDescribe(conn: NWConnection, host: String, port: UInt16, uri: String) {
+        sendRTSPRequest(conn, method: "DESCRIBE", uri: uri,
+                        extraHeaders: "Accept: application/sdp\r\n") { [weak self] response in
+            guard let self, let response else {
+                self?.failRTSP("DESCRIBE failed", host: host, port: port)
+                return
+            }
+            guard let status = self.parseRTSPStatusCode(response), status == 200 else {
+                self.failRTSP("DESCRIBE rejected", host: host, port: port)
+                return
+            }
+            logger.info("RTSP DESCRIBE OK")
+            // SDP parsed but we don't strictly need it — we know the format
+            self.sendRTSPSetup(conn: conn, host: host, port: port, uri: uri)
+        }
+    }
+
+    private func sendRTSPSetup(conn: NWConnection, host: String, port: UInt16, uri: String) {
+        let transport = "Transport: RTP/AVP;unicast;client_port=\(rtpPort)-\(rtpPort + 1)\r\n"
+        logger.info("RTSP SETUP: client_port=\(self.rtpPort)-\(self.rtpPort + 1)")
+
+        sendRTSPRequest(conn, method: "SETUP", uri: uri,
+                        extraHeaders: transport) { [weak self] response in
+            guard let self, let response else {
+                self?.failRTSP("SETUP failed", host: host, port: port)
+                return
+            }
+            guard let status = self.parseRTSPStatusCode(response), status == 200 else {
+                self.failRTSP("SETUP rejected", host: host, port: port)
+                return
+            }
+
+            // Extract Session header
+            if let sessionHeader = self.parseRTSPHeader(response, name: "Session") {
+                // Strip timeout suffix if present
+                let sessionId = sessionHeader.split(separator: ";").first.map(String.init) ?? sessionHeader
+                self.rtspSessionId = sessionId
+            }
+
+            logger.info("RTSP SETUP OK, session=\(self.rtspSessionId ?? "?")")
+            self.sendRTSPPlay(conn: conn, host: host, port: port, uri: uri)
+        }
+    }
+
+    private func sendRTSPPlay(conn: NWConnection, host: String, port: UInt16, uri: String) {
+        let sessionHeader = rtspSessionId.map { "Session: \($0)\r\n" } ?? ""
+
+        sendRTSPRequest(conn, method: "PLAY", uri: uri,
+                        extraHeaders: sessionHeader) { [weak self] response in
+            guard let self, let response else {
+                self?.failRTSP("PLAY failed", host: host, port: port)
+                return
+            }
+            guard let status = self.parseRTSPStatusCode(response), status == 200 else {
+                self.failRTSP("PLAY rejected", host: host, port: port)
+                return
+            }
+
+            logger.info("RTSP PLAY OK — streaming started")
+            DispatchQueue.main.async {
+                self.isConnecting = false
+                self.isConnected = true
+                self.connectionStatus = "Streaming (RTP)"
+            }
+        }
+    }
+
+    private func sendRTSPTeardown(conn: NWConnection, sessionId: String) {
+        // Best-effort teardown, don't wait for response
+        let seq = nextCSeq()
+        let request = "TEARDOWN rtsp://localhost/camera0 RTSP/1.0\r\nCSeq: \(seq)\r\nSession: \(sessionId)\r\n\r\n"
+        conn.send(content: Data(request.utf8), completion: .contentProcessed { _ in })
+    }
+
+    private func failRTSP(_ message: String, host: String, port: UInt16) {
+        retryRTSP(host: host, port: port, reason: message)
+    }
+}
+
+// MARK: - Helper: withUnsafeBufferPointers for Array of Data
+
+private extension Array where Element == Data {
+    func withUnsafeBufferPointers<R>(_ body: (UnsafePointer<UnsafePointer<UInt8>>) -> R) -> R {
+        let ptrs = UnsafeMutablePointer<UnsafePointer<UInt8>>.allocate(capacity: count)
+        defer { ptrs.deallocate() }
+        return withNestedUnsafeBytes(index: 0, ptrs: ptrs, body: body)
+    }
+
+    private func withNestedUnsafeBytes<R>(
+        index: Int,
+        ptrs: UnsafeMutablePointer<UnsafePointer<UInt8>>,
+        body: (UnsafePointer<UnsafePointer<UInt8>>) -> R
+    ) -> R {
+        if index >= count {
+            return body(UnsafePointer(ptrs))
+        }
+        return self[index].withUnsafeBytes { rawPtr in
+            ptrs[index] = rawPtr.baseAddress!.assumingMemoryBound(to: UInt8.self)
+            return withNestedUnsafeBytes(index: index + 1, ptrs: ptrs, body: body)
+        }
+    }
+}

--- a/driver/hevc/Info.plist
+++ b/driver/hevc/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>HEVC Receiver</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>26.0</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/imujoco/app/app/simulation_manager.swift
+++ b/imujoco/app/app/simulation_manager.swift
@@ -225,7 +225,7 @@ final class SimulationInstance: Identifiable, MJCRenderDataSource, MJCVideoDataS
         videoStreamer?.start()
 
         // VLC-facing streamer (MJPEG/HTTP, RTP/RTSP, or HEVC/QUIC per user setting)
-        // QUIC uses cameraPort directly (UDP); MJPEG/RTSP use TCP so no conflict
+        // All modes use cameraPort directly; RTP (UDP) + RTSP (TCP) share the port number
         if vlcStreamer == nil {
             if !vlcTransportModeExplicit {
                 let setting = UserDefaults.standard.integer(forKey: "videoTransport")

--- a/imujoco/video/video/mjc_video_rtp_transport.mm
+++ b/imujoco/video/video/mjc_video_rtp_transport.mm
@@ -78,6 +78,19 @@ bool MJVideoRTPTransport::Start(uint16_t port) {
     int sndbuf = 256 * 1024;
     setsockopt(socket_fd_, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf));
 
+    // Bind to port so RTP packets have a predictable source address.
+    // Clients use NWConnection to this port for bidirectional UDP flow.
+    struct sockaddr_in bind_addr{};
+    bind_addr.sin_family = AF_INET;
+    bind_addr.sin_addr.s_addr = INADDR_ANY;
+    bind_addr.sin_port = htons(port);
+    if (bind(socket_fd_, reinterpret_cast<struct sockaddr*>(&bind_addr), sizeof(bind_addr)) < 0) {
+        os_log_error(OS_LOG_DEFAULT, "RTP: Failed to bind UDP port %u: %{errno}d", port, errno);
+        close(socket_fd_);
+        socket_fd_ = -1;
+        return false;
+    }
+
     port_ = port;
     active_.store(true, std::memory_order_release);
     packet_buffer_.reserve(kRTPHeaderSize + kMaxRTPPayloadSize);

--- a/imujoco/video/video/mjc_video_streamer.swift
+++ b/imujoco/video/video/mjc_video_streamer.swift
@@ -57,8 +57,8 @@ public struct MJCVideoStreamerConfig {
     public var transportMode: MJCVideoTransportMode = .rawUDP
     /// JPEG quality for JPEG-based modes (0.0-1.0, default 0.8)
     public var jpegQuality: CGFloat = 0.8
-    /// RTSP server port for rtpRTSP mode (default: 8554)
-    public var rtspPort: UInt16 = 8554
+    /// RTSP server port for rtpRTSP mode (default: same as port)
+    public var rtspPort: UInt16 = 9100
     public init() {}
 }
 
@@ -170,9 +170,9 @@ public final class MJCVideoStreamer {
             }
 
         case .rtpRTSP:
-            let rtpPort = config.port + 2
+            let rtpPort = config.port
             guard let rtp = rtpTransport, rtp.Start(rtpPort) else {
-                logger.error("Failed to start RTP transport on port \(self.config.port + 2)")
+                logger.error("Failed to start RTP transport on port \(self.config.port)")
                 return
             }
             if let rtsp = rtspServer {


### PR DESCRIPTION
## Summary

- **Unify RTP/RTSP ports**: eliminate the `+2` port offset — TCP (RTSP) and UDP (RTP) now share `cameraPort` (e.g. 9100), matching the QUIC model
- **Add HEVC/RTP receiver app** (`driver/hevc/`): macOS SwiftUI app that connects via RTSP, receives HEVC video over RTP, decodes with VideoToolbox hardware decoder
- **Fix RTP transport**: bind UDP socket to its port so packets have a predictable source address for client NWConnection
- **Fix receiver UDP reception**: use outgoing NWConnection instead of NWListener (blocked by macOS firewall for unsigned apps), fix isComplete early-return that stopped the receive loop after one datagram
- **UX**: Connect/Cancel/Disconnect button states, auto-retry RTSP with 3s timeout when server is unavailable

## Test plan

- [x] `bazel build //driver:hevc_receiver` — compiles
- [x] `bazel build //imujoco/app:app` — compiles
- [x] HEVC receiver connects to iPad running RTP/RTSP mode, displays video
- [x] VLC `rtsp://<ip>:9100/camera0` still works
- [x] Cancel button aborts connecting state
- [x] Auto-retry connects when server starts after client

🤖 Generated with [Claude Code](https://claude.com/claude-code)