### PR TITLE
fix: replace audio background mode with BGProcessingTask

### DIFF
--- a/imujoco/app/Info.plist
+++ b/imujoco/app/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocalNetworkUsageDescription</key>
@@ -39,7 +39,11 @@
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>
-		<string>audio</string>
+		<string>processing</string>
+	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.hhkblogi.imujoco.app.simulation</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/imujoco/app/app/app.swift
+++ b/imujoco/app/app/app.swift
@@ -2,12 +2,21 @@ import SwiftUI
 #if canImport(UIKit)
 import UIKit
 #endif
+#if canImport(BackgroundTasks)
+import BackgroundTasks
+#endif
 
 @main
 struct MuJoCoApp: App {
     @State private var gridManager = SimulationGridManager()
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("caffeineMode") private var caffeineMode: Int = 1  // 0=off, 1=half, 2=full
+
+    init() {
+        #if os(iOS)
+        SimulationGridManager.registerBackgroundTask()
+        #endif
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -41,6 +50,11 @@ struct MuJoCoApp: App {
                     }
                 }
                 #if os(iOS)
+                .onReceive(NotificationCenter.default.publisher(for: .caffeineBackgroundTaskLaunched)) { notification in
+                    if let task = notification.object as? BGProcessingTask {
+                        gridManager.handleCaffeineTask(task)
+                    }
+                }
                 .onChange(of: caffeineMode) { _, level in
                     UIApplication.shared.isIdleTimerDisabled = level >= 1
                     if level < 2 {

--- a/imujoco/app/app/simulation_grid_view.swift
+++ b/imujoco/app/app/simulation_grid_view.swift
@@ -589,7 +589,7 @@ struct SettingsView: View {
                             .popover(isPresented: $showCaffeineInfo) {
                                 VStack(alignment: .leading, spacing: 4) {
                                     Text("**Half** — Screen stays on. Simulations pause when you leave the app.")
-                                    Text("**Full** — Screen stays on. Simulations keep running even when you lock the screen.")
+                                    Text("**Full** — Screen stays on. Requests background time so simulations may continue when you leave the app.")
                                 }
                                 .fixedSize(horizontal: false, vertical: true)
                                 .font(.caption)

--- a/imujoco/app/app/simulation_manager.swift
+++ b/imujoco/app/app/simulation_manager.swift
@@ -10,8 +10,8 @@ import MJCPhysicsRuntime
 #if canImport(UIKit)
 import UIKit
 #endif
-#if canImport(AVFoundation)
-import AVFoundation
+#if canImport(BackgroundTasks)
+import BackgroundTasks
 #endif
 
 private let logger = Logger(subsystem: "com.mujoco.app", category: "SimulationManager")
@@ -588,13 +588,15 @@ final class SimulationGridManager: @unchecked Sendable {
         UIApplication.shared.endBackgroundTask(backgroundTaskID)
         backgroundTaskID = .invalid
     }
-    // MARK: - Caffeine Background (silent audio keep-alive)
+    // MARK: - Caffeine Background (BGProcessingTask)
 
-    private var silentPlayer: AVAudioPlayer?
+    static let caffeineTaskID = "com.hhkblogi.imujoco.app.simulation"
+
+    private var caffeineActive = false
 
     @MainActor
     func beginCaffeineBackground() {
-        guard silentPlayer == nil else { return }
+        guard !caffeineActive else { return }
 
         let hasRunning = instances.contains { $0.state == .running }
         guard hasRunning else {
@@ -602,59 +604,67 @@ final class SimulationGridManager: @unchecked Sendable {
             return
         }
 
-        do {
-            let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.playback, options: .mixWithOthers)
-            try session.setActive(true)
-
-            let player = try AVAudioPlayer(data: Self.silentWAV)
-            player.numberOfLoops = -1  // loop forever
-            player.volume = 0
-            player.prepareToPlay()
-
-            if player.play() {
-                silentPlayer = player
-                logger.info("Caffeine background audio started")
-            } else {
-                logger.error("Caffeine background audio failed: AVAudioPlayer.play() returned false")
-                player.stop()
-                try? session.setActive(false, options: .notifyOthersOnDeactivation)
-            }
-        } catch {
-            logger.error("Caffeine background audio failed: \(error.localizedDescription)")
-            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-        }
+        caffeineActive = true
+        scheduleCaffeineTask()
+        logger.info("Caffeine background requested via BGProcessingTask")
     }
 
     @MainActor
     func endCaffeineBackground() {
-        guard let player = silentPlayer else { return }
-        player.stop()
-        silentPlayer = nil
-        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-        logger.info("Caffeine background audio stopped")
+        guard caffeineActive else { return }
+        caffeineActive = false
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.caffeineTaskID)
+        logger.info("Caffeine background cancelled")
     }
 
-    /// Minimal 1-second silent WAV (44100 Hz, mono, 16-bit).
-    private static let silentWAV: Data = {
-        let sampleRate: UInt32 = 44100
-        let numSamples: UInt32 = sampleRate
-        let dataSize = numSamples * 2  // 16-bit mono
-        var d = Data(capacity: 44 + Int(dataSize))
-        func append16(_ v: UInt16) { withUnsafeBytes(of: v.littleEndian) { d.append(contentsOf: $0) } }
-        func append32(_ v: UInt32) { withUnsafeBytes(of: v.littleEndian) { d.append(contentsOf: $0) } }
-        d.append(contentsOf: [0x52,0x49,0x46,0x46])  // "RIFF"
-        append32(36 + dataSize)
-        d.append(contentsOf: [0x57,0x41,0x56,0x45])  // "WAVE"
-        d.append(contentsOf: [0x66,0x6D,0x74,0x20])  // "fmt "
-        append32(16); append16(1); append16(1)        // PCM, mono
-        append32(sampleRate); append32(sampleRate * 2) // byte rate
-        append16(2); append16(16)                      // block align, bits
-        d.append(contentsOf: [0x64,0x61,0x74,0x61])  // "data"
-        append32(dataSize)
-        d.append(Data(count: Int(dataSize)))           // silence
-        return d
-    }()
+    private func scheduleCaffeineTask() {
+        let request = BGProcessingTaskRequest(identifier: Self.caffeineTaskID)
+        request.requiresNetworkConnectivity = false
+        request.requiresExternalPower = false
+        request.earliestBeginDate = nil  // run as soon as possible
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            logger.debug("BGProcessingTask scheduled")
+        } catch {
+            logger.error("Failed to schedule BGProcessingTask: \(error.localizedDescription)")
+        }
+    }
+
+    /// Called when the system launches our BGProcessingTask.
+    @MainActor
+    func handleCaffeineTask(_ task: BGProcessingTask) {
+        logger.info("BGProcessingTask started by system")
+
+        task.expirationHandler = {
+            logger.info("BGProcessingTask expiring")
+        }
+
+        // Keep the task alive while caffeine is active
+        // When done (or app returns to foreground), complete it
+        if caffeineActive {
+            // Re-schedule for next opportunity
+            scheduleCaffeineTask()
+        }
+
+        // Mark complete — the simulation threads keep running independently
+        // until the process is suspended. Re-scheduling above asks the system
+        // to wake us again.
+        task.setTaskCompleted(success: true)
+    }
+
+    /// Must be called before app finishes launching (e.g. in App.init).
+    static func registerBackgroundTask() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: caffeineTaskID,
+            using: .main
+        ) { task in
+            guard let processingTask = task as? BGProcessingTask else { return }
+            NotificationCenter.default.post(
+                name: .caffeineBackgroundTaskLaunched,
+                object: processingTask
+            )
+        }
+    }
 
     #else
     func beginBackgroundExecution() {}
@@ -662,4 +672,10 @@ final class SimulationGridManager: @unchecked Sendable {
     func beginCaffeineBackground() {}
     func endCaffeineBackground() {}
     #endif
+}
+
+// MARK: - Notification for BGProcessingTask bridging
+
+extension Notification.Name {
+    static let caffeineBackgroundTaskLaunched = Notification.Name("caffeineBackgroundTaskLaunched")
 }


### PR DESCRIPTION
## Summary
- Replace `UIBackgroundModes: audio` with `UIBackgroundModes: processing` using BGProcessingTask
- Bump build number to 5
- Cherry-pick from v0.1.1 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)