### PR TITLE
feat: auto-discover provisioning profiles, App Store distribution build

### DIFF
--- a/imujoco/app/BUILD.bazel
+++ b/imujoco/app/BUILD.bazel
@@ -1,11 +1,11 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load("@rules_apple//apple:apple.bzl", "local_provisioning_profile")
 load("@rules_apple//apple:ios.bzl", "ios_application")
 load("@rules_apple//apple:macos.bzl", "macos_application")
 load("@rules_apple//apple:resources.bzl", "apple_resource_group")
 load("@rules_apple//apple:tvos.bzl", "tvos_application")
 load("@rules_xcodeproj//xcodeproj:xcode_provisioning_profile.bzl", "xcode_provisioning_profile")
-load(":team_config.bzl", "APPSTORE_PROFILE_NAME", "DEV_PROFILE_NAME", "TEAM_ID")
+load(":appstore.bzl", "appstore_targets")
+load(":team_config.bzl", "APPSTORE_IDENTITY", "TEAM_ID")
 
 # ============================================================================
 # App Swift library
@@ -43,23 +43,21 @@ swift_library(
 # Provisioning profile (for device deployment via Xcode)
 # ============================================================================
 
-local_provisioning_profile(
+APP_BUNDLE_ID = "com.hhkblogi.imujoco.app"
+
+genrule(
     name = "local_profile",
-    profile_name = DEV_PROFILE_NAME,
-    team_id = TEAM_ID,
+    outs = ["iMuJoCo.mobileprovision"],
+    cmd = "$(location //scripts:find_profile.sh) " + TEAM_ID + " " + APP_BUNDLE_ID + " $@ dev",
+    local = True,
+    tags = ["no-cache"],
+    tools = ["//scripts:find_profile.sh"],
 )
 
 xcode_provisioning_profile(
     name = "xcode_profile",
     managed_by_xcode = True,
     provisioning_profile = ":local_profile",
-    team_id = TEAM_ID,
-)
-
-local_provisioning_profile(
-    name = "appstore_profile",
-    profile_name = APPSTORE_PROFILE_NAME,
-    tags = ["manual"],
     team_id = TEAM_ID,
 )
 
@@ -119,29 +117,14 @@ ios_application(
 )
 
 # ============================================================================
-# iOS application — App Store submission
+# iOS application — App Store submission (conditional on APPSTORE_IDENTITY)
 # ============================================================================
 
-ios_application(
-    name = "app_ios_appstore",
-    app_icons = glob(["app/AppIcon.icon/**"]),
-    bundle_id = "com.hhkblogi.imujoco.app",
-    entitlements = "app_ios.entitlements",
-    families = [
-        "iphone",
-        "ipad",
-    ],
-    infoplists = ["Info.plist"],
-    minimum_os_version = "26.0",
-    provisioning_profile = ":appstore_profile",
-    resources = glob(["app/Assets.xcassets/**"]) + [
-        "app/PrivacyInfo.xcprivacy",
-        "//models",
-        "//imujoco/render:mujoco_metallib",
-    ],
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-    deps = [":app_lib"],
+appstore_targets(
+    appstore_identity = APPSTORE_IDENTITY,
+    team_id = TEAM_ID,
+    app_bundle_id = APP_BUNDLE_ID,
+    find_profile_tool = "//scripts:find_profile.sh",
 )
 
 # ============================================================================

--- a/imujoco/app/BUILD.bazel
+++ b/imujoco/app/BUILD.bazel
@@ -5,7 +5,7 @@ load("@rules_apple//apple:resources.bzl", "apple_resource_group")
 load("@rules_apple//apple:tvos.bzl", "tvos_application")
 load("@rules_xcodeproj//xcodeproj:xcode_provisioning_profile.bzl", "xcode_provisioning_profile")
 load(":appstore.bzl", "appstore_targets")
-load(":team_config.bzl", "APPSTORE_IDENTITY", "TEAM_ID")
+load(":team_config.bzl", "TEAM_ID")
 
 # ============================================================================
 # App Swift library
@@ -117,11 +117,10 @@ ios_application(
 )
 
 # ============================================================================
-# iOS application — App Store submission (conditional on APPSTORE_IDENTITY)
+# iOS application — App Store submission
 # ============================================================================
 
 appstore_targets(
-    appstore_identity = APPSTORE_IDENTITY,
     team_id = TEAM_ID,
     app_bundle_id = APP_BUNDLE_ID,
     find_profile_tool = "//scripts:find_profile.sh",

--- a/imujoco/app/Info.plist
+++ b/imujoco/app/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.2</string>
+	<string>0.1.3</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>9</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocalNetworkUsageDescription</key>

--- a/imujoco/app/appstore.bzl
+++ b/imujoco/app/appstore.bzl
@@ -1,25 +1,22 @@
-"""Conditionally registers App Store distribution targets."""
+"""App Store distribution targets (tagged manual — skipped by bazel build //...)."""
 
 load("@rules_apple//apple:ios.bzl", "ios_application")
 
-def appstore_targets(name = "appstore", appstore_identity = "", team_id = "", app_bundle_id = "", find_profile_tool = ""):
-    """Creates App Store distribution targets when APPSTORE_IDENTITY is configured.
+def appstore_targets(name = "appstore", team_id = "", app_bundle_id = "", find_profile_tool = ""):
+    """Creates App Store distribution targets.
 
-    When APPSTORE_IDENTITY is empty (the default), no distribution targets
-    are created. This allows `bazel build //...` to work for developers
-    who only need dev builds.
+    All targets are tagged "manual" so they are skipped by `bazel build //...`.
+    Building explicitly (e.g. `bazel build //imujoco/app:app_ios_appstore
+    --config=appstore`) will invoke find_profile.sh, which fails with a clear
+    error if no App Store profile is installed.
 
     Args:
         name: Macro name (unused, required by Bazel convention).
-        appstore_identity: Signing identity string (e.g. "Apple Distribution: Name (TEAM)").
-                           When empty, no targets are created.
         team_id: Apple Developer Team ID.
         app_bundle_id: App bundle identifier (e.g. "com.hhkblogi.imujoco.app").
         find_profile_tool: Label for the find_profile.sh script.
     """
     _ = name  # unused, required by convention
-    if not appstore_identity:
-        return
 
     native.genrule(
         name = "appstore_profile",

--- a/imujoco/app/appstore.bzl
+++ b/imujoco/app/appstore.bzl
@@ -1,0 +1,56 @@
+"""Conditionally registers App Store distribution targets."""
+
+load("@rules_apple//apple:ios.bzl", "ios_application")
+
+def appstore_targets(name = "appstore", appstore_identity = "", team_id = "", app_bundle_id = "", find_profile_tool = ""):
+    """Creates App Store distribution targets when APPSTORE_IDENTITY is configured.
+
+    When APPSTORE_IDENTITY is empty (the default), no distribution targets
+    are created. This allows `bazel build //...` to work for developers
+    who only need dev builds.
+
+    Args:
+        name: Macro name (unused, required by Bazel convention).
+        appstore_identity: Signing identity string (e.g. "Apple Distribution: Name (TEAM)").
+                           When empty, no targets are created.
+        team_id: Apple Developer Team ID.
+        app_bundle_id: App bundle identifier (e.g. "com.hhkblogi.imujoco.app").
+        find_profile_tool: Label for the find_profile.sh script.
+    """
+    _ = name  # unused, required by convention
+    if not appstore_identity:
+        return
+
+    native.genrule(
+        name = "appstore_profile",
+        outs = ["iMuJoCo_AppStore.mobileprovision"],
+        cmd = "$(location " + find_profile_tool + ") " + team_id + " " + app_bundle_id + " $@ appstore",
+        tools = [find_profile_tool],
+        local = True,
+        tags = [
+            "manual",
+            "no-cache",
+        ],
+    )
+
+    ios_application(
+        name = "app_ios_appstore",
+        app_icons = native.glob(["app/AppIcon.icon/**"]),
+        bundle_id = app_bundle_id,
+        entitlements = "app_ios.entitlements",
+        families = [
+            "iphone",
+            "ipad",
+        ],
+        infoplists = ["Info.plist"],
+        minimum_os_version = "26.0",
+        provisioning_profile = ":appstore_profile",
+        resources = native.glob(["app/Assets.xcassets/**"]) + [
+            "app/PrivacyInfo.xcprivacy",
+            "//models",
+            "//imujoco/render:mujoco_metallib",
+        ],
+        tags = ["manual"],
+        visibility = ["//visibility:public"],
+        deps = [":app_lib"],
+    )

--- a/imujoco/app/team_config.bzl.template
+++ b/imujoco/app/team_config.bzl.template
@@ -4,8 +4,10 @@
 
 TEAM_ID = "YOUR_TEAM_ID_HERE"
 
-# Development provisioning profile name (shown in Apple Developer portal)
-DEV_PROFILE_NAME = "iOS Team Provisioning Profile: *"
-
-# App Store distribution provisioning profile name (shown in Apple Developer portal)
-APPSTORE_PROFILE_NAME = "YOUR_APPSTORE_PROFILE_NAME_HERE"
+# Apple Distribution signing identity for App Store builds.
+# Leave empty ("") for development-only setups — App Store targets will be
+# skipped by `bazel build //...`.
+# To find your identity:
+#   security find-identity -v -p codesigning | grep "Apple Distribution"
+# Example: "Apple Distribution: YOUR NAME (TEAM_ID)"
+APPSTORE_IDENTITY = ""

--- a/imujoco/app/team_config.bzl.template
+++ b/imujoco/app/team_config.bzl.template
@@ -3,11 +3,3 @@
 # team_config.bzl is gitignored and will not be committed.
 
 TEAM_ID = "YOUR_TEAM_ID_HERE"
-
-# Apple Distribution signing identity for App Store builds.
-# Leave empty ("") for development-only setups — App Store targets will be
-# skipped by `bazel build //...`.
-# To find your identity:
-#   security find-identity -v -p codesigning | grep "Apple Distribution"
-# Example: "Apple Distribution: YOUR NAME (TEAM_ID)"
-APPSTORE_IDENTITY = ""

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files(
+    ["find_profile.sh"],
+    visibility = ["//visibility:public"],
+)

--- a/scripts/find_profile.sh
+++ b/scripts/find_profile.sh
@@ -5,7 +5,8 @@
 #
 # Searches both Xcode-managed and manually-installed profile directories.
 # Matches by application-identifier (team_id.bundle_id) in the profile's
-# entitlements, not by profile name.
+# entitlements, not by profile name. For dev profiles, also accepts
+# wildcard Xcode-managed profiles (team_id.*), preferring exact matches.
 #
 # Profile type is detected by the presence of ProvisionedDevices key:
 #   - Development profiles have ProvisionedDevices + get-task-allow=true
@@ -21,6 +22,7 @@ BUNDLE_ID="$2"
 OUTPUT="$3"
 TYPE="${4:-dev}"
 EXPECTED_APPID="${TEAM_ID}.${BUNDLE_ID}"
+WILDCARD_APPID="${TEAM_ID}.*"
 
 USER_HOME="${HOME:-$(eval echo ~)}"
 
@@ -33,12 +35,17 @@ PROFILE_DIRS=(
 INSTALLED_FPS=$(security find-identity -v -p codesigning 2>/dev/null | \
     awk '{ print $2 }' | grep -E '^[A-F0-9]{40}$' || true)
 
-# Best candidates: "expiration_epoch|path" (cert-matched and fallback).
+# Best candidates, split by exact vs wildcard match (cert-matched and fallback).
 # When multiple profiles match, the one expiring latest wins.
-BEST=""
-BEST_EXPIRY=0
-FALLBACK=""
-FALLBACK_EXPIRY=0
+# Priority: cert-exact > cert-wildcard > fallback-exact > fallback-wildcard.
+BEST_EXACT=""
+BEST_EXACT_EXPIRY=0
+BEST_WILD=""
+BEST_WILD_EXPIRY=0
+FALLBACK_EXACT=""
+FALLBACK_EXACT_EXPIRY=0
+FALLBACK_WILD=""
+FALLBACK_WILD_EXPIRY=0
 
 for dir in "${PROFILE_DIRS[@]}"; do
     [ -d "$dir" ] || continue
@@ -47,7 +54,13 @@ for dir in "${PROFILE_DIRS[@]}"; do
         decoded=$(security cms -D -i "$f" 2>/dev/null) || continue
         appid=$(printf '%s' "$decoded" | \
             xmllint --xpath '//key[text()="application-identifier"]/following-sibling::string[1]/text()' - 2>/dev/null) || continue
-        if [ "$appid" != "$EXPECTED_APPID" ]; then
+        # Match exact bundle ID, or wildcard (TEAMID.*) for dev profiles.
+        is_wildcard=false
+        if [ "$appid" = "$EXPECTED_APPID" ]; then
+            : # exact match
+        elif [ "$appid" = "$WILDCARD_APPID" ] && [ "$TYPE" = "dev" ]; then
+            is_wildcard=true
+        else
             continue
         fi
         # Filter by profile type:
@@ -90,30 +103,49 @@ except Exception:
             fi
         done
         if [ "$cert_matched" = true ]; then
-            if [ "$exp_epoch" -gt "$BEST_EXPIRY" ] 2>/dev/null; then
-                BEST="$f"
-                BEST_EXPIRY="$exp_epoch"
+            if [ "$is_wildcard" = true ]; then
+                if [ "$exp_epoch" -gt "$BEST_WILD_EXPIRY" ] 2>/dev/null; then
+                    BEST_WILD="$f"
+                    BEST_WILD_EXPIRY="$exp_epoch"
+                fi
+            else
+                if [ "$exp_epoch" -gt "$BEST_EXACT_EXPIRY" ] 2>/dev/null; then
+                    BEST_EXACT="$f"
+                    BEST_EXACT_EXPIRY="$exp_epoch"
+                fi
             fi
         else
-            if [ "$exp_epoch" -gt "$FALLBACK_EXPIRY" ] 2>/dev/null; then
-                FALLBACK="$f"
-                FALLBACK_EXPIRY="$exp_epoch"
+            if [ "$is_wildcard" = true ]; then
+                if [ "$exp_epoch" -gt "$FALLBACK_WILD_EXPIRY" ] 2>/dev/null; then
+                    FALLBACK_WILD="$f"
+                    FALLBACK_WILD_EXPIRY="$exp_epoch"
+                fi
+            else
+                if [ "$exp_epoch" -gt "$FALLBACK_EXACT_EXPIRY" ] 2>/dev/null; then
+                    FALLBACK_EXACT="$f"
+                    FALLBACK_EXACT_EXPIRY="$exp_epoch"
+                fi
             fi
         fi
     done
 done
 
-if [ -n "$BEST" ]; then
-    cp "$BEST" "$OUTPUT"
-    exit 0
-fi
+# Priority: cert-exact > cert-wildcard > fallback-exact > fallback-wildcard
+for candidate in "$BEST_EXACT" "$BEST_WILD"; do
+    if [ -n "$candidate" ]; then
+        cp "$candidate" "$OUTPUT"
+        exit 0
+    fi
+done
 
-if [ -n "$FALLBACK" ]; then
-    echo "WARNING: No $TYPE profile found whose cert matches an installed identity." >&2
-    echo "  Using fallback: $FALLBACK" >&2
-    cp "$FALLBACK" "$OUTPUT"
-    exit 0
-fi
+for candidate in "$FALLBACK_EXACT" "$FALLBACK_WILD"; do
+    if [ -n "$candidate" ]; then
+        echo "WARNING: No $TYPE profile found whose cert matches an installed identity." >&2
+        echo "  Using fallback: $candidate" >&2
+        cp "$candidate" "$OUTPUT"
+        exit 0
+    fi
+done
 
 echo "ERROR: No $TYPE provisioning profile found for $EXPECTED_APPID" >&2
 echo "  Install a $TYPE profile for bundle ID '$BUNDLE_ID' (team $TEAM_ID)" >&2

--- a/scripts/find_profile.sh
+++ b/scripts/find_profile.sh
@@ -10,6 +10,9 @@
 # Profile type is detected by the presence of ProvisionedDevices key:
 #   - Development profiles have ProvisionedDevices + get-task-allow=true
 #   - App Store distribution profiles do NOT have ProvisionedDevices
+#
+# When multiple profiles match, the one expiring latest is chosen
+# (most recently renewed), giving deterministic results.
 
 set -eo pipefail
 
@@ -30,7 +33,12 @@ PROFILE_DIRS=(
 INSTALLED_FPS=$(security find-identity -v -p codesigning 2>/dev/null | \
     awk '{ print $2 }' | grep -E '^[A-F0-9]{40}$' || true)
 
+# Best candidates: "expiration_epoch|path" (cert-matched and fallback).
+# When multiple profiles match, the one expiring latest wins.
+BEST=""
+BEST_EXPIRY=0
 FALLBACK=""
+FALLBACK_EXPIRY=0
 
 for dir in "${PROFILE_DIRS[@]}"; do
     [ -d "$dir" ] || continue
@@ -58,31 +66,47 @@ for dir in "${PROFILE_DIRS[@]}"; do
         if [ "$profile_type" != "$TYPE" ]; then
             continue
         fi
-        # Prefer profiles whose cert matches an installed signing identity.
-        profile_fps=$(printf '%s' "$decoded" | python3 -c '
+        # Extract expiration date (epoch) and cert fingerprints in one pass.
+        eval_output=$(printf '%s' "$decoded" | python3 -c '
 import sys, plistlib, hashlib
 try:
     d = plistlib.loads(sys.stdin.buffer.read())
+    exp = d.get("ExpirationDate")
+    print(int(exp.timestamp()) if exp else 0)
     for cert_der in d.get("DeveloperCertificates", []):
         print(hashlib.sha1(cert_der).hexdigest().upper())
 except Exception:
-    pass
+    print(0)
 ' 2>/dev/null)
-        matched=false
+        exp_epoch=$(echo "$eval_output" | head -1)
+        profile_fps=$(echo "$eval_output" | tail -n +2)
+
+        # Check if any cert in the profile matches an installed signing identity.
+        cert_matched=false
         for pfp in $profile_fps; do
             if echo "$INSTALLED_FPS" | grep -q "$pfp"; then
-                matched=true
+                cert_matched=true
                 break
             fi
         done
-        if [ "$matched" = true ]; then
-            cp "$f" "$OUTPUT"
-            exit 0
+        if [ "$cert_matched" = true ]; then
+            if [ "$exp_epoch" -gt "$BEST_EXPIRY" ] 2>/dev/null; then
+                BEST="$f"
+                BEST_EXPIRY="$exp_epoch"
+            fi
+        else
+            if [ "$exp_epoch" -gt "$FALLBACK_EXPIRY" ] 2>/dev/null; then
+                FALLBACK="$f"
+                FALLBACK_EXPIRY="$exp_epoch"
+            fi
         fi
-        # Keep as fallback if no cert-matching profile found
-        [ -z "$FALLBACK" ] && FALLBACK="$f"
     done
 done
+
+if [ -n "$BEST" ]; then
+    cp "$BEST" "$OUTPUT"
+    exit 0
+fi
 
 if [ -n "$FALLBACK" ]; then
     echo "WARNING: No $TYPE profile found whose cert matches an installed identity." >&2

--- a/scripts/find_profile.sh
+++ b/scripts/find_profile.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# find_profile.sh — Find a provisioning profile by bundle ID and team ID.
+# Usage: find_profile.sh <team_id> <bundle_id> <output_path> [type]
+#   type: "dev" (default) or "appstore"
+#
+# Searches both Xcode-managed and manually-installed profile directories.
+# Matches by application-identifier (team_id.bundle_id) in the profile's
+# entitlements, not by profile name.
+#
+# Profile type is detected by the presence of ProvisionedDevices key:
+#   - Development profiles have ProvisionedDevices + get-task-allow=true
+#   - App Store distribution profiles do NOT have ProvisionedDevices
+
+set -eo pipefail
+
+TEAM_ID="$1"
+BUNDLE_ID="$2"
+OUTPUT="$3"
+TYPE="${4:-dev}"
+EXPECTED_APPID="${TEAM_ID}.${BUNDLE_ID}"
+
+USER_HOME="${HOME:-$(eval echo ~)}"
+
+PROFILE_DIRS=(
+    "$USER_HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"
+    "$USER_HOME/Library/MobileDevice/Provisioning Profiles"
+)
+
+# Collect SHA-1 fingerprints of installed signing identities (certs with private keys)
+INSTALLED_FPS=$(security find-identity -v -p codesigning 2>/dev/null | \
+    awk '{ print $2 }' | grep -E '^[A-F0-9]{40}$' || true)
+
+FALLBACK=""
+
+for dir in "${PROFILE_DIRS[@]}"; do
+    [ -d "$dir" ] || continue
+    for f in "$dir"/*.mobileprovision "$dir"/*.provisionprofile; do
+        [ -f "$f" ] || continue
+        decoded=$(security cms -D -i "$f" 2>/dev/null) || continue
+        appid=$(printf '%s' "$decoded" | \
+            xmllint --xpath '//key[text()="application-identifier"]/following-sibling::string[1]/text()' - 2>/dev/null) || continue
+        if [ "$appid" != "$EXPECTED_APPID" ]; then
+            continue
+        fi
+        # Filter by profile type:
+        #   dev:      has ProvisionedDevices AND get-task-allow=true
+        #   appstore: no ProvisionedDevices (Ad Hoc profiles have ProvisionedDevices
+        #             but get-task-allow=false, so they're excluded from "dev")
+        if printf '%s' "$decoded" | grep -q '<key>ProvisionedDevices</key>'; then
+            if printf '%s' "$decoded" | grep -A1 '<key>get-task-allow</key>' | grep -q '<true/>'; then
+                profile_type="dev"
+            else
+                profile_type="adhoc"
+            fi
+        else
+            profile_type="appstore"
+        fi
+        if [ "$profile_type" != "$TYPE" ]; then
+            continue
+        fi
+        # Prefer profiles whose cert matches an installed signing identity.
+        profile_fps=$(printf '%s' "$decoded" | python3 -c '
+import sys, plistlib, hashlib
+try:
+    d = plistlib.loads(sys.stdin.buffer.read())
+    for cert_der in d.get("DeveloperCertificates", []):
+        print(hashlib.sha1(cert_der).hexdigest().upper())
+except Exception:
+    pass
+' 2>/dev/null)
+        matched=false
+        for pfp in $profile_fps; do
+            if echo "$INSTALLED_FPS" | grep -q "$pfp"; then
+                matched=true
+                break
+            fi
+        done
+        if [ "$matched" = true ]; then
+            cp "$f" "$OUTPUT"
+            exit 0
+        fi
+        # Keep as fallback if no cert-matching profile found
+        [ -z "$FALLBACK" ] && FALLBACK="$f"
+    done
+done
+
+if [ -n "$FALLBACK" ]; then
+    echo "WARNING: No $TYPE profile found whose cert matches an installed identity." >&2
+    echo "  Using fallback: $FALLBACK" >&2
+    cp "$FALLBACK" "$OUTPUT"
+    exit 0
+fi
+
+echo "ERROR: No $TYPE provisioning profile found for $EXPECTED_APPID" >&2
+echo "  Install a $TYPE profile for bundle ID '$BUNDLE_ID' (team $TEAM_ID)" >&2
+exit 1


### PR DESCRIPTION
## Summary
- Replace fragile name-based `local_provisioning_profile` with `genrule` + `find_profile.sh` that discovers profiles by `application-identifier` entitlement and profile type (dev/appstore)
- Simplify `team_config.bzl` — only `TEAM_ID` is needed (removed `DEV_PROFILE_NAME` / `APPSTORE_PROFILE_NAME`). Existing local copies work without changes.
- App Store targets are always registered with `manual` tags — `bazel build //...` skips them, no extra config needed
- Bump version to 0.1.3 (build 9)

## How it works
`find_profile.sh` searches both Xcode-managed and manually-installed profile directories, matches by `team_id.bundle_id` in profile entitlements (with wildcard `TEAMID.*` support for dev profiles), and differentiates dev vs appstore by the presence of the `ProvisionedDevices` key. When multiple profiles match, the one expiring latest is chosen for deterministic results. Exact bundle-ID matches are preferred over wildcards.

## Test plan
- [x] `find_profile.sh` correctly finds dev profile (exact and wildcard)
- [x] `find_profile.sh` correctly finds appstore profile
- [x] `bazel build //imujoco/app:local_profile` succeeds
- [x] `bazel build //imujoco/app:appstore_profile` succeeds
- [x] `bazel build //...` succeeds (72 targets)
- [x] `bazel build //imujoco/app:app_ios_appstore --config=appstore` produces signed IPA
- [x] IPA codesigning verified: `Apple Distribution: XIAOCHEN WANG (GJ6VBRTZLY)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)